### PR TITLE
Fix merge first and last name

### DIFF
--- a/app/controllers/auth/omniauth_controller.rb
+++ b/app/controllers/auth/omniauth_controller.rb
@@ -39,8 +39,7 @@ module Auth
 
       # New user
       attrs = {
-        :first_name => first_name,
-        :last_name => last_name,
+        :name => name,
         :email => email.downcase,
         :tos_accepted => true
       }
@@ -74,12 +73,15 @@ module Auth
     end
 
     def sync_information
-      @resource.first_name ||= first_name
-      @resource.last_name ||= last_name
+      @resource.name = name
     end
 
     def email
       (auth_hash['info']['email'] || (auth_hash['extra'] && auth_hash['extra']['mail'])).downcase
+    end
+
+    def name
+      "#{first_name} #{last_name}".strip
     end
 
     def first_name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,8 +11,7 @@ class User < ApplicationRecord
   # Properties
   #
 
-  property :first_name
-  property :last_name
+  property :name
   property :email
   property :locale
   property :token_version
@@ -52,7 +51,7 @@ class User < ApplicationRecord
   ##
   # Validations
   #
-  validates :first_name,
+  validates :name,
             :presence => true
 
   validates :email,
@@ -86,10 +85,6 @@ class User < ApplicationRecord
     return nil unless user
     raise JSONAPI::Exceptions::UnconfirmedError unless user.confirmed?
     user
-  end
-
-  def name
-    last_name? ? "#{first_name} #{last_name}" : first_name
   end
 
   def increment_token_version

--- a/app/resources/user_resource.rb
+++ b/app/resources/user_resource.rb
@@ -43,7 +43,7 @@ class UserResource < ApplicationResource
   end
 
   def self.creatable_fields(context = {})
-    super(context) - %i[decks collaborations conversions]
+    super(context) - %i[topics collaborations]
   end
 
   def self.updatable_fields(context = {})

--- a/app/resources/user_resource.rb
+++ b/app/resources/user_resource.rb
@@ -7,8 +7,7 @@ class UserResource < ApplicationResource
   ##
   # Attributes
   #
-  attribute :first_name
-  attribute :last_name
+  attribute :name
   attribute :email
   attribute :locale
   attribute :password
@@ -26,8 +25,7 @@ class UserResource < ApplicationResource
   ##
   # Filters
   #
-  filter :first_name
-  filter :last_name
+  filter :name
   filter :email
 
   ##

--- a/app/views/comment_mailer/create.html.erb
+++ b/app/views/comment_mailer/create.html.erb
@@ -1,7 +1,7 @@
-<p>Hello <%= @comment.conversation.user.first_name %>!</p>
+<p>Hello <%= @comment.conversation.user.name %>!</p>
 
 <p>
-  <strong><%= "#{@user.first_name} #{@user.last_name}" %></strong> posted a comment on your conversation <strong><%= @comment.conversation.title %></strong>:
+  <strong><%= @user.name %></strong> posted a comment on your conversation <strong><%= @comment.conversation.title %></strong>:
 </p>
 
 <p>

--- a/app/views/conversation_mailer/create.html.erb
+++ b/app/views/conversation_mailer/create.html.erb
@@ -1,7 +1,7 @@
-<p>Hello <%= @topic.user.first_name %>!</p>
+<p>Hello <%= @topic.user.name %>!</p>
 
 <p>
-  <strong><%= "#{@user.first_name} #{@user.last_name}" %></strong> posted a <%= @conversation.conversation_type %> on the slide topic <strong><%= @topic.title %></strong>:
+  <strong><%= @user.name %></strong> posted a <%= @conversation.conversation_type %> on the slide topic <strong><%= @topic.title %></strong>:
 </p>
 
 <p>

--- a/db/migrate/20180724070926_merge_first_name_and_last_name_into_name.rb
+++ b/db/migrate/20180724070926_merge_first_name_and_last_name_into_name.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class MergeFirstNameAndLastNameIntoName < ActiveRecord::Migration[5.2]
+  def self.up
+    add_column :users, :name, :string, :default => '', :null => false
+
+    User.transaction do
+      User.all.each do |user|
+        user.update :name => "#{user.first_name}#{user.last_name ? " #{user.last_name}" : ''}"
+      end
+    end
+
+    remove_column :users, :first_name
+    remove_column :users, :last_name
+  end
+
+  def self.down
+    add_column :users, :first_name, :string, :default => '', :null => false
+    add_column :users, :last_name, :string
+
+    User.transaction do
+      User.all.each do |user|
+        user.update :first_name => user.name
+      end
+    end
+
+    remove_column :users, :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_04_26_120902) do
+ActiveRecord::Schema.define(version: 2018_07_24_070926) do
 
   create_table "annotations", force: :cascade do |t|
     t.string "type"
@@ -87,8 +87,6 @@ ActiveRecord::Schema.define(version: 2018_04_26_120902) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "first_name", default: "", null: false
-    t.string "last_name"
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -106,6 +104,7 @@ ActiveRecord::Schema.define(version: 2018_04_26_120902) do
     t.integer "token_version", default: 1, null: false
     t.boolean "tos_accepted"
     t.string "locale", default: "", null: false
+    t.string "name", default: "", null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/lib/tasks/guest.rake
+++ b/lib/tasks/guest.rake
@@ -19,7 +19,7 @@ namespace :guest do
 
         user = User.new :email => email,
                         :password => password,
-                        :first_name => 'Guest',
+                        :name => 'Guest',
                         :tos_accepted => true
 
         user.skip_confirmation!

--- a/lib/tasks/sample.rake
+++ b/lib/tasks/sample.rake
@@ -41,12 +41,9 @@ namespace :db do
         puts "Creating user #{i + 1}/#{user_count}"
 
         user = User.new :email => Faker::Internet.email,
-                        :first_name => Faker::Name.first_name,
+                        :name => Faker::Name.name,
                         :password => Faker::Internet.password,
                         :tos_accepted => true
-
-        # 90% of the users have a last name
-        user.last_name = Faker::Name.last_name if prob 0.9
 
         # 90% of the users are confirmed
         user.confirm if prob 0.9

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -2,8 +2,7 @@
 
 FactoryBot.define do
   factory :user do
-    first_name { Faker::Name.first_name }
-    last_name { Faker::Name.last_name }
+    name { Faker::Name.name }
     email { Faker::Internet.email }
     password { Faker::Internet.password 6 }
     password_confirmation { password }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe User, :type => :model do
   let(:confirmed_user) { create :user, :confirmed }
 
   describe 'attributes' do
-    it { is_expected.not_to allow_value(nil).for(:first_name) }
-    it { is_expected.not_to allow_value('').for(:first_name) }
+    it { is_expected.not_to allow_value(nil).for(:name) }
+    it { is_expected.not_to allow_value('').for(:name) }
 
     it { is_expected.not_to allow_value(nil).for(:email) }
     it { is_expected.not_to allow_value('').for(:email) }
@@ -81,12 +81,6 @@ RSpec.describe User, :type => :model do
 
       user.increment_token_version!
       expect(user.token_version).to eq token_version + 1
-    end
-
-    it 'returns a correct full name' do
-      expect(build(:user, :first_name => 'foo', :last_name => nil).name).to eq 'foo'
-      expect(build(:user, :first_name => 'foo', :last_name => '').name).to eq 'foo'
-      expect(build(:user, :first_name => 'foo', :last_name => 'bar').name).to eq 'foo bar'
     end
   end
 

--- a/spec/policies/annotation_policy_scope_spec.rb
+++ b/spec/policies/annotation_policy_scope_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe AnnotationPolicy::Scope do
   end
 
   context 'for user 1' do
-    let(:user) { User.find_by :first_name => 'user1' }
+    let(:user) { User.find_by :name => 'user1' }
 
     it 'should show annotations of public, protected, owned and collaborated topics' do
       expect(subject.count).to eq 36
@@ -24,7 +24,7 @@ RSpec.describe AnnotationPolicy::Scope do
   end
 
   context 'for user 2' do
-    let(:user) { User.find_by :first_name => 'user2' }
+    let(:user) { User.find_by :name => 'user2' }
 
     it 'should show annotations of public, protected, owned and collaborated topics' do
       expect(subject.count).to eq 36
@@ -32,7 +32,7 @@ RSpec.describe AnnotationPolicy::Scope do
   end
 
   context 'for user 3' do
-    let(:user) { User.find_by :first_name => 'user3' }
+    let(:user) { User.find_by :name => 'user3' }
 
     it 'should show annotations of public, protected, owned and collaborated topics' do
       expect(subject.count).to eq 36
@@ -40,7 +40,7 @@ RSpec.describe AnnotationPolicy::Scope do
   end
 
   context 'for user 4' do
-    let(:user) { User.find_by :first_name => 'user4' }
+    let(:user) { User.find_by :name => 'user4' }
 
     it 'should show annotations of public, protected, owned and collaborated topics' do
       expect(subject.count).to eq 27

--- a/spec/policies/asset_policy_scope_spec.rb
+++ b/spec/policies/asset_policy_scope_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe AssetPolicy::Scope do
   end
 
   context 'for user 1' do
-    let(:user) { User.find_by :first_name => 'user1' }
+    let(:user) { User.find_by :name => 'user1' }
 
     it 'should show assets of public, protected, owned and collaborated topics' do
       expect(subject.count).to eq 36
@@ -24,7 +24,7 @@ RSpec.describe AssetPolicy::Scope do
   end
 
   context 'for user 2' do
-    let(:user) { User.find_by :first_name => 'user2' }
+    let(:user) { User.find_by :name => 'user2' }
 
     it 'should show assets of public, protected, owned and collaborated topics' do
       expect(subject.count).to eq 36
@@ -32,7 +32,7 @@ RSpec.describe AssetPolicy::Scope do
   end
 
   context 'for user 3' do
-    let(:user) { User.find_by :first_name => 'user3' }
+    let(:user) { User.find_by :name => 'user3' }
 
     it 'should show assets of public, protected, owned and collaborated topics' do
       expect(subject.count).to eq 36
@@ -40,7 +40,7 @@ RSpec.describe AssetPolicy::Scope do
   end
 
   context 'for user 4' do
-    let(:user) { User.find_by :first_name => 'user4' }
+    let(:user) { User.find_by :name => 'user4' }
 
     it 'should show assets of public, protected, owned and collaborated topics' do
       expect(subject.count).to eq 27

--- a/spec/policies/comment_policy_scope_spec.rb
+++ b/spec/policies/comment_policy_scope_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CommentPolicy::Scope do
   end
 
   context 'for user 1' do
-    let(:user) { User.find_by :first_name => 'user1' }
+    let(:user) { User.find_by :name => 'user1' }
 
     it 'should show annotations of public, protected, owned and collaborated topics' do
       expect(subject.count).to eq 36
@@ -28,7 +28,7 @@ RSpec.describe CommentPolicy::Scope do
   end
 
   context 'for user 2' do
-    let(:user) { User.find_by :first_name => 'user2' }
+    let(:user) { User.find_by :name => 'user2' }
 
     it 'should show annotations of public, protected, owned and collaborated topics' do
       expect(subject.count).to eq 36
@@ -36,7 +36,7 @@ RSpec.describe CommentPolicy::Scope do
   end
 
   context 'for user 3' do
-    let(:user) { User.find_by :first_name => 'user3' }
+    let(:user) { User.find_by :name => 'user3' }
 
     it 'should show annotations of public, protected, owned and collaborated topics' do
       expect(subject.count).to eq 36
@@ -44,7 +44,7 @@ RSpec.describe CommentPolicy::Scope do
   end
 
   context 'for user 4' do
-    let(:user) { User.find_by :first_name => 'user4' }
+    let(:user) { User.find_by :name => 'user4' }
 
     it 'should show annotations of public, protected, owned and collaborated topics' do
       expect(subject.count).to eq 27

--- a/spec/policies/conversation_policy_scope_spec.rb
+++ b/spec/policies/conversation_policy_scope_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ConversationPolicy::Scope do
   end
 
   context 'for user 1' do
-    let(:user) { User.find_by :first_name => 'user1' }
+    let(:user) { User.find_by :name => 'user1' }
 
     it 'should show annotations of public, protected, owned and collaborated topics' do
       expect(subject.count).to eq 36
@@ -28,7 +28,7 @@ RSpec.describe ConversationPolicy::Scope do
   end
 
   context 'for user 2' do
-    let(:user) { User.find_by :first_name => 'user2' }
+    let(:user) { User.find_by :name => 'user2' }
 
     it 'should show annotations of public, protected, owned and collaborated topics' do
       expect(subject.count).to eq 36
@@ -36,7 +36,7 @@ RSpec.describe ConversationPolicy::Scope do
   end
 
   context 'for user 3' do
-    let(:user) { User.find_by :first_name => 'user3' }
+    let(:user) { User.find_by :name => 'user3' }
 
     it 'should show annotations of public, protected, owned and collaborated topics' do
       expect(subject.count).to eq 36
@@ -44,7 +44,7 @@ RSpec.describe ConversationPolicy::Scope do
   end
 
   context 'for user 4' do
-    let(:user) { User.find_by :first_name => 'user4' }
+    let(:user) { User.find_by :name => 'user4' }
 
     it 'should show annotations of public, protected, owned and collaborated topics' do
       expect(subject.count).to eq 27

--- a/spec/policies/topic_policy_scope_spec.rb
+++ b/spec/policies/topic_policy_scope_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe TopicPolicy::Scope do
     end
 
     context 'for user 1' do
-      let(:user) { User.find_by :first_name => 'user1' }
+      let(:user) { User.find_by :name => 'user1' }
 
       it 'should show public, protected, owned and collaborated topics' do
         expect(subject.pluck :title).to match_array %w[u1d1 u1d2 u1d3 u1d4 u2d1 u2d2 u2d4 u3d1 u3d2 u3d4 u4d1 u4d2]
@@ -25,7 +25,7 @@ RSpec.describe TopicPolicy::Scope do
     end
 
     context 'for user 2' do
-      let(:user) { User.find_by :first_name => 'user2' }
+      let(:user) { User.find_by :name => 'user2' }
 
       it 'should show public, protected, owned and collaborated topics' do
         expect(subject.pluck :title).to match_array %w[u1d1 u1d2 u1d4 u2d1 u2d2 u2d3 u2d4 u3d1 u3d2 u3d4 u4d1 u4d2]
@@ -33,7 +33,7 @@ RSpec.describe TopicPolicy::Scope do
     end
 
     context 'for user 3' do
-      let(:user) { User.find_by :first_name => 'user3' }
+      let(:user) { User.find_by :name => 'user3' }
 
       it 'should show public, protected, owned and collaborated topics' do
         expect(subject.pluck :title).to match_array %w[u1d1 u1d2 u1d4 u2d1 u2d2 u2d4 u3d1 u3d2 u3d3 u3d4 u4d1 u4d2]
@@ -41,7 +41,7 @@ RSpec.describe TopicPolicy::Scope do
     end
 
     context 'for user 4' do
-      let(:user) { User.find_by :first_name => 'user4' }
+      let(:user) { User.find_by :name => 'user4' }
 
       it 'should show public, protected, owned and collaborated topics' do
         expect(subject.pluck :title).to match_array %w[u1d1 u1d2 u2d1 u2d2 u3d1 u3d2 u4d1 u4d2 u4d3]
@@ -50,7 +50,7 @@ RSpec.describe TopicPolicy::Scope do
   end
 
   context 'a users topics' do
-    subject { described_class.new(user, User.find_by(:first_name => 'user1').topics).resolve }
+    subject { described_class.new(user, User.find_by(:name => 'user1').topics).resolve }
 
     include_context 'policy_sample'
 
@@ -63,7 +63,7 @@ RSpec.describe TopicPolicy::Scope do
     end
 
     context 'for user 1' do
-      let(:user) { User.find_by :first_name => 'user1' }
+      let(:user) { User.find_by :name => 'user1' }
 
       it 'should show public, protected, owned and collaborated topics' do
         expect(subject.pluck :title).to match_array %w[u1d1 u1d2 u1d3 u1d4]
@@ -71,7 +71,7 @@ RSpec.describe TopicPolicy::Scope do
     end
 
     context 'for user 2' do
-      let(:user) { User.find_by :first_name => 'user2' }
+      let(:user) { User.find_by :name => 'user2' }
 
       it 'should show public, protected and collaborated topics' do
         expect(subject.pluck :title).to match_array %w[u1d1 u1d2 u1d4]
@@ -79,7 +79,7 @@ RSpec.describe TopicPolicy::Scope do
     end
 
     context 'for user 3' do
-      let(:user) { User.find_by :first_name => 'user3' }
+      let(:user) { User.find_by :name => 'user3' }
 
       it 'should show public, protected and collaborated topics' do
         expect(subject.pluck :title).to match_array %w[u1d1 u1d2 u1d4]
@@ -87,7 +87,7 @@ RSpec.describe TopicPolicy::Scope do
     end
 
     context 'for user 4' do
-      let(:user) { User.find_by :first_name => 'user4' }
+      let(:user) { User.find_by :name => 'user4' }
 
       it 'should show public, protected and collaborated topics' do
         expect(subject.pluck :title).to match_array %w[u1d1 u1d2]

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -5,14 +5,13 @@ require 'rails_helper'
 RSpec.describe 'User API', :type => :request do
   let(:user) { create :user, :confirmed }
 
-  let(:first_name) { Faker::Name.first_name }
-  let(:last_name) { Faker::Name.last_name }
+  let(:name) { Faker::Name.name }
   let(:password) { Faker::Internet.password 6 }
 
   let(:attributes) do
     {
       :email => Faker::Internet.email,
-      :firstName => first_name,
+      :name => name,
       :password => password,
       :tosAccepted => true
     }
@@ -86,7 +85,7 @@ RSpec.describe 'User API', :type => :request do
     end
 
     it 'rejects no first name' do
-      post users_path, :params => request_body(attributes.except :firstName), :headers => headers
+      post users_path, :params => request_body(attributes.except :name), :headers => headers
 
       expect(response.status).to eq 422
       expect(jsonapi_error_code(response)).to eq JSONAPI::VALIDATION_ERROR
@@ -102,7 +101,7 @@ RSpec.describe 'User API', :type => :request do
       json = JSON.parse response.body
 
       # Email is hidden for unauthenticated users
-      expect(json['data']['attributes']).to match 'firstName' => attributes[:firstName]
+      expect(json['data']['attributes']).to match 'name' => attributes[:name]
     end
   end
 
@@ -134,7 +133,7 @@ RSpec.describe 'User API', :type => :request do
     end
 
     it 'rejects id not equal to URL' do
-      patch user_path(:id => user.id), :params => update_body(999, :firstName => 'foo'), :headers => headers
+      patch user_path(:id => user.id), :params => update_body(999, :name => 'foo'), :headers => headers
 
       expect(response.status).to eq 400
       expect(jsonapi_error_code(response)).to eq JSONAPI::KEY_NOT_INCLUDED_IN_URL
@@ -142,7 +141,7 @@ RSpec.describe 'User API', :type => :request do
     end
 
     it 'rejects non-existant users' do
-      patch user_path(:id => 999), :params => update_body(999, :firstName => 'foo'), :headers => headers
+      patch user_path(:id => 999), :params => update_body(999, :name => 'foo'), :headers => headers
 
       expect(response.status).to eq 404
       expect(jsonapi_error_code(response)).to eq JSONAPI::RECORD_NOT_FOUND
@@ -165,24 +164,14 @@ RSpec.describe 'User API', :type => :request do
       expect(response.content_type).to eq JSONAPI::MEDIA_TYPE
     end
 
-    it 'updates firstName' do
-      expect(user.first_name).not_to eq first_name
-      patch user_path(:id => user.id), :params => update_body(user.id, :firstName => first_name), :headers => headers
+    it 'updates name' do
+      expect(user.name).not_to eq name
+      patch user_path(:id => user.id), :params => update_body(user.id, :name => name), :headers => headers
 
       user.reload
       expect(response.status).to eq 200
       expect(response.content_type).to eq JSONAPI::MEDIA_TYPE
-      expect(user.first_name).to eq first_name
-    end
-
-    it 'updates lastName' do
-      expect(user.last_name).not_to eq last_name
-      patch user_path(:id => user.id), :params => update_body(user.id, :lastName => last_name), :headers => headers
-
-      user.reload
-      expect(response.status).to eq 200
-      expect(response.content_type).to eq JSONAPI::MEDIA_TYPE
-      expect(user.last_name).to eq last_name
+      expect(user.name).to eq name
     end
 
     it 'updates password' do

--- a/spec/resources/user_resource_spec.rb
+++ b/spec/resources/user_resource_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe UserResource, :type => :resource do
 
   it { is_expected.to have_primary_key :id }
 
-  it { is_expected.to have_attribute :first_name }
-  it { is_expected.to have_attribute :last_name }
+  it { is_expected.to have_attribute :name }
   it { is_expected.not_to have_attribute :locale }
   it { is_expected.not_to have_attribute :email }
   it { is_expected.not_to have_attribute :tos_accepted }
@@ -22,40 +21,40 @@ RSpec.describe UserResource, :type => :resource do
   describe 'fields' do
     context 'for a guest' do
       it 'should have a valid set of fetchable fields' do
-        expect(subject.fetchable_fields).to match_array %i[id first_name last_name topics collaborations]
+        expect(subject.fetchable_fields).to match_array %i[id name topics collaborations]
       end
     end
 
     context 'for a user' do
       let(:context) { { :current_user => build(:user) } }
       it 'should have a valid set of fetchable fields' do
-        expect(subject.fetchable_fields).to match_array %i[id first_name last_name topics collaborations]
+        expect(subject.fetchable_fields).to match_array %i[id name topics collaborations]
       end
     end
 
     context 'for the same user' do
       let(:context) { { :current_user => user } }
       it 'should have a valid set of fetchable fields' do
-        expect(subject.fetchable_fields).to match_array %i[id first_name last_name locale email topics collaborations]
+        expect(subject.fetchable_fields).to match_array %i[id name locale email topics collaborations]
       end
     end
 
     it 'should have a valid set of creatable fields' do
-      expect(described_class.creatable_fields).to match_array %i[first_name last_name email password tos_accepted]
+      expect(described_class.creatable_fields).to match_array %i[name email password tos_accepted]
     end
 
     it 'should have a valid set of updatable fields' do
-      expect(described_class.updatable_fields).to match_array %i[first_name last_name password topics collaborations conversions]
+      expect(described_class.updatable_fields).to match_array %i[name password topics collaborations conversions]
     end
 
     it 'should have a valid set of sortable fields' do
-      expect(described_class.sortable_fields context).to match_array %i[id first_name last_name email]
+      expect(described_class.sortable_fields context).to match_array %i[id name email]
     end
   end
 
   describe 'filters' do
     it 'should have a valid set of filters' do
-      expect(described_class.filters.keys).to match_array %i[id first_name last_name email]
+      expect(described_class.filters.keys).to match_array %i[id name email]
     end
   end
 end

--- a/spec/resources/user_resource_spec.rb
+++ b/spec/resources/user_resource_spec.rb
@@ -40,11 +40,11 @@ RSpec.describe UserResource, :type => :resource do
     end
 
     it 'should have a valid set of creatable fields' do
-      expect(described_class.creatable_fields).to match_array %i[name email password tos_accepted]
+      expect(described_class.creatable_fields).to match_array %i[name email locale password tos_accepted]
     end
 
     it 'should have a valid set of updatable fields' do
-      expect(described_class.updatable_fields).to match_array %i[name password topics collaborations conversions]
+      expect(described_class.updatable_fields).to match_array %i[name locale password topics collaborations]
     end
 
     it 'should have a valid set of sortable fields' do

--- a/spec/support/policy_sample_context.rb
+++ b/spec/support/policy_sample_context.rb
@@ -3,10 +3,10 @@
 RSpec.shared_context 'policy_sample', :shared_context => :metadata do
   before :each do
     ActiveRecord::Base.transaction do
-      u1 = create :user, :confirmed, :first_name => 'user1'
-      u2 = create :user, :confirmed, :first_name => 'user2'
-      u3 = create :user, :confirmed, :first_name => 'user3'
-      u4 = create :user, :confirmed, :first_name => 'user4'
+      u1 = create :user, :confirmed, :name => 'user1'
+      u2 = create :user, :confirmed, :name => 'user2'
+      u3 = create :user, :confirmed, :name => 'user3'
+      u4 = create :user, :confirmed, :name => 'user4'
 
       # User 1
       u1d1 = create :topic, :with_assets, :with_conversations, :user => u1, :title => 'u1d1'


### PR DESCRIPTION
Merge users' `first_name` and `last_name` into `name`. Includes database migrations.