### PR TITLE
Disable /notifications/:id and relationship routes

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
 class NotificationsController < ApplicationController
-  include Relationships
-  include RelatedResources
-
   # Authentication
   after_action :renew_token
 
   # Authorization
-  after_action :verify_authorized, :except => %i[index show_relationship get_related_resources]
-  after_action :verify_policy_scoped, :only => %i[index get_related_resources]
-  after_action :verify_authorized_or_policy_scoped, :only => :show_relationship
+  after_action :verify_authorized, :except => %i[index]
+  after_action :verify_policy_scoped, :only => %i[index]
 
   ##
   # Resource
@@ -22,19 +18,4 @@ class NotificationsController < ApplicationController
 
     jsonapi_render :json => @notifications
   end
-
-  # GET /notifications/:id
-  def show
-    @notification = Notification.find params[:id]
-
-    authorize @notification
-
-    jsonapi_render :json => @notification
-  end
-
-  ##
-  # Relationships
-  #
-  # Relationships and related resource actions are implemented in the respective concerns
-  #
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,15 +70,7 @@ Rails.application.routes.draw do
     ##
     # Notifications API (immutable)
     #
-    jsonapi_resources :notifications, :only => %i[index show] do
-      # Topic relationship
-      jsonapi_related_resource :topic
-      jsonapi_link :topic, :only => :show
-
-      # User relationship
-      jsonapi_related_resource :user
-      jsonapi_link :user, :only => :show
-    end
+    jsonapi_resources :notifications, :only => %i[index] do end
 
     ##
     # Annotations API

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -29,24 +29,4 @@ RSpec.describe NotificationsController do
       it { is_expected.to return_token }
     end
   end
-
-  describe 'show' do
-    context 'unauthenticated' do
-      before { get :show, :params => { :id => notification.id } }
-
-      it { is_expected.not_to be_protected }
-      it { is_expected.not_to return_token }
-    end
-
-    context 'authenticated' do
-      before do
-        add_auth_header
-        @request.headers.merge! @headers
-        get :show, :params => { :id => notification.id }
-      end
-
-      it { is_expected.not_to be_protected }
-      it { is_expected.to return_token }
-    end
-  end
 end

--- a/spec/requests/notification_spec.rb
+++ b/spec/requests/notification_spec.rb
@@ -29,33 +29,4 @@ RSpec.describe 'Notification API', :type => :request do
       expect(notification['meta']).to include 'createdAt'
     end
   end
-
-  describe 'GET /:id' do
-    before do
-    end
-
-    it 'rejects non-existant notifications' do
-      get notification_path(:id => 999), :headers => headers
-
-      expect(response.status).to eq 404
-      expect(response.content_type).to eq JSONAPI::MEDIA_TYPE
-    end
-
-    it 'returns a notification' do
-      get notification_path(:id => notification.id), :headers => headers
-
-      expect(response.status).to eq 200
-      expect(response.content_type).to eq JSONAPI::MEDIA_TYPE
-
-      json = JSON.parse response.body
-      expect(json).to include 'data'
-
-      notification = json['data']
-      expect(notification).to include 'attributes'
-      expect(notification['attributes']).to include 'eventType'
-      expect(notification['attributes']).to include 'userName'
-      expect(notification['attributes']).to include 'topicTitle'
-      expect(notification['meta']).to include 'createdAt'
-    end
-  end
 end

--- a/spec/routing/notifications_routing_spec.rb
+++ b/spec/routing/notifications_routing_spec.rb
@@ -16,33 +16,7 @@ RSpec.describe 'notifications routing', :type => :routing do
   it 'routes notification endpoint' do
     route = '/api/notifications/foo'
 
-    expect(:get => route).to route_to 'notifications#show', :id => 'foo'
-    expect(:patch => route).not_to be_routable
-    expect(:put => route).not_to be_routable
-    expect(:post => route).not_to be_routable
-    expect(:delete => route).not_to be_routable
-  end
-
-  it 'routes notification user relationship endpoint' do
-    route = '/api/notifications/foo/relationships/user'
-    params = { :notification_id => 'foo', :relationship => 'user' }
-
-    expect(:get => '/api/notifications/foo/user').to route_to 'users#get_related_resource', params.merge(:source => 'notifications')
-
-    expect(:get => route).to route_to 'notifications#show_relationship', params
-    expect(:patch => route).not_to be_routable
-    expect(:put => route).not_to be_routable
-    expect(:post => route).not_to be_routable
-    expect(:delete => route).not_to be_routable
-  end
-
-  it 'routes notification topic relationship endpoint' do
-    route = '/api/notifications/foo/relationships/topic'
-    params = { :notification_id => 'foo', :relationship => 'topic' }
-
-    expect(:get => '/api/notifications/foo/topic').to route_to 'topics#get_related_resource', params.merge(:source => 'notifications')
-
-    expect(:get => route).to route_to 'notifications#show_relationship', params
+    expect(:get => route).not_to be_routable
     expect(:patch => route).not_to be_routable
     expect(:put => route).not_to be_routable
     expect(:post => route).not_to be_routable


### PR DESCRIPTION
Disable some Notifications API routes so only the `index` route is available.