### PR TITLE
Add root content item

### DIFF
--- a/app/commands/repository/asset/destroy.rb
+++ b/app/commands/repository/asset/destroy.rb
@@ -9,7 +9,7 @@ module Repository
       attr_accessor :author
 
       def execute
-        raise ArgumentError, 'No author specified' unless @author
+        raise OpenWebslides::ArgumentError, 'No author specified' unless @author
 
         File.delete asset_file
 

--- a/app/commands/repository/asset/update.rb
+++ b/app/commands/repository/asset/update.rb
@@ -9,8 +9,8 @@ module Repository
       attr_accessor :author, :content
 
       def execute
-        raise ArgumentError, 'No author specified' unless @author
-        raise ArgumentError, 'No content specified' unless @content
+        raise OpenWebslides::ArgumentError, 'No author specified' unless @author
+        raise OpenWebslides::ArgumentError, 'No content specified' unless @content
 
         exists = File.exist? asset_file
 

--- a/app/commands/repository/filesystem/write.rb
+++ b/app/commands/repository/filesystem/write.rb
@@ -16,10 +16,10 @@ module Repository
 
         # Find root content item
         root = @content.find { |c| c['type'] == 'contentItemTypes/ROOT' }
-        raise OpenWebslides::FormatError, 'No root content item found' unless root
+        raise OpenWebslides::NoRootContentItemError unless root
 
         # Ensure root content item is the same as the database version
-        validate_root_content_item_id root
+        raise OpenWebslides::InvalidRootContentItemError unless root['id'] == @receiver.root_content_item_id
 
         # Write index file including root content item identifier
         write_index 'root' => root['id']
@@ -34,19 +34,10 @@ module Repository
       private
 
       ##
-      # Validate the root content item id to be equal to the database root content item id
-      #
-      def validate_root_content_item_id(root)
-        return if root['id'] == @receiver.root_content_item_id
-
-        raise OpenWebslides::FormatError, 'Root content item ID must be the same as previously stored'
-      end
-
-      ##
       # Write a content item to the repository
       #
       def write_content_item(content_item)
-        raise OpenWebslides::FormatError, 'No valid identifier found' unless content_item['id']
+        raise OpenWebslides::FormatError unless content_item['id']
 
         file_path = File.join content_path, "#{content_item['id']}.yml"
 

--- a/app/commands/repository/filesystem/write.rb
+++ b/app/commands/repository/filesystem/write.rb
@@ -14,8 +14,14 @@ module Repository
         # Ensure repository data format version is compatible
         validate_version
 
-        # Write index file including root content item identifier
+        # Find root content item
         root = @content.find { |c| c['type'] == 'contentItemTypes/ROOT' }
+        raise OpenWebslides::FormatError, 'No root content item found' unless root
+
+        # Ensure root content item is the same as the database version
+        validate_root_content_item_id root
+
+        # Write index file including root content item identifier
         write_index 'root' => root['id']
 
         # Write content item files
@@ -26,6 +32,15 @@ module Repository
       end
 
       private
+
+      ##
+      # Validate the root content item id to be equal to the database root content item id
+      #
+      def validate_root_content_item_id(root)
+        return if root['id'] == @receiver.root_content_item_id
+
+        raise OpenWebslides::FormatError, 'Root content item ID must be the same as previously stored'
+      end
 
       ##
       # Write a content item to the repository

--- a/app/commands/repository/filesystem/yaml_command.rb
+++ b/app/commands/repository/filesystem/yaml_command.rb
@@ -20,14 +20,9 @@ module Repository
         constraint = Semverse::Constraint.new "~> #{OpenWebslides.config.repository.version}"
 
         yaml = YAML.safe_load File.read index_file
-        raise 'Version string not found' unless yaml&.key? 'version'
 
         repository_version = yaml['version']
-        return if constraint.satisfies? repository_version
-
-        raise "Cannot satisfy repository data format version #{repository_version}, server has #{VERSION}"
-      rescue StandardError => e
-        raise OpenWebslides::FormatError, e
+        raise OpenWebslides::IncompatibleVersionError unless constraint.satisfies? repository_version
       end
 
       ##

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -34,8 +34,8 @@ class ContentController < ApplicationController
     service.update :author => current_user, :content => content
 
     head :no_content
-  rescue JSON::ParserError
-    jsonapi_render_bad_request
+  rescue OpenWebslides::FormatError => e
+    raise JSONAPI::Exceptions::FormatError, e.error_type
   end
 
   ##

--- a/app/errors/jsonapi/exceptions/format_error.rb
+++ b/app/errors/jsonapi/exceptions/format_error.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module JSONAPI
+  module Exceptions
+    class FormatError < Error
+      attr_accessor :error_type
+
+      def initialize(error_type = :format, error_object_overrides = {})
+        @error_type = error_type
+
+        super error_object_overrides
+      end
+
+      def errors
+        params = {
+          :code => JSONAPI::VALIDATION_ERROR,
+          :status => :unprocessable_entity,
+          :title => I18n.translate("jsonapi-resources.exceptions.#{error_type}.title"),
+          :detail => I18n.translate("jsonapi-resources.exceptions.#{error_type}.detail")
+        }
+
+        [create_error_object(params)]
+      end
+    end
+  end
+end

--- a/app/errors/open_webslides/argument_error.rb
+++ b/app/errors/open_webslides/argument_error.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
 module OpenWebslides
+  ##
+  # ArgumentError
+  #
+  # An argument provided was missing or invalid
+  #
   class ArgumentError < Error; end
 end

--- a/app/errors/open_webslides/configuration_error.rb
+++ b/app/errors/open_webslides/configuration_error.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-module OpenWebslides
-  class ConfigurationError < Error; end
-end

--- a/app/errors/open_webslides/error.rb
+++ b/app/errors/open_webslides/error.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
 module OpenWebslides
+  ##
+  # Base error class
+  #
   class Error < StandardError; end
 end

--- a/app/errors/open_webslides/format_error.rb
+++ b/app/errors/open_webslides/format_error.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
 module OpenWebslides
-  class FormatError < Error; end
+  ##
+  # Content data format error
+  #
+  class FormatError < Error
+    # Type of data format error, used for i18n string lookup
+    attr_accessor :error_type
+
+    def initialize(error_type = :format)
+      @error_type = error_type
+    end
+  end
 end

--- a/app/errors/open_webslides/incompatible_version_error.rb
+++ b/app/errors/open_webslides/incompatible_version_error.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module OpenWebslides
+  ##
+  # Incompatible version - raised when a repository has a different, unsatisfiable version than the server
+  #
+  class IncompatibleVersionError < FormatError
+    def initialize
+      super :incompatible_version
+    end
+  end
+end

--- a/app/errors/open_webslides/invalid_root_content_item_error.rb
+++ b/app/errors/open_webslides/invalid_root_content_item_error.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module OpenWebslides
+  ##
+  # Invalid root content item - raised when the root content item id does not match the identifier in the database
+  #
+  class InvalidRootContentItemError < FormatError
+    def initialize
+      super :invalid_root_content_item
+    end
+  end
+end

--- a/app/errors/open_webslides/no_root_content_item_error.rb
+++ b/app/errors/open_webslides/no_root_content_item_error.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module OpenWebslides
+  ##
+  # No root content item found in the content
+  #
+  class NoRootContentItemError < FormatError
+    def initialize
+      super :no_root_content_item
+    end
+  end
+end

--- a/app/errors/open_webslides/not_implemented_error.rb
+++ b/app/errors/open_webslides/not_implemented_error.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
 module OpenWebslides
+  ##
+  # Not implemented yet
+  #
   class NotImplementedError < Error; end
 end

--- a/app/errors/open_webslides/repo_does_not_exist_error.rb
+++ b/app/errors/open_webslides/repo_does_not_exist_error.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
 module OpenWebslides
+  ##
+  # Repo does not exist in the filesystem
+  #
   class RepoDoesNotExistError < Error; end
 end

--- a/app/errors/open_webslides/repo_exists_error.rb
+++ b/app/errors/open_webslides/repo_exists_error.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
 module OpenWebslides
+  ##
+  # Repo already exists in the filesystem
+  #
   class RepoExistsError < Error; end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -17,6 +17,9 @@ class Topic < ApplicationRecord
   # Access level
   enum :state => %i[public_access protected_access private_access]
 
+  # Root content item identifier
+  property :root_content_item_id
+
   ##
   # Associations
   #
@@ -50,8 +53,14 @@ class Topic < ApplicationRecord
   ##
   # Validations
   #
-  validates :title, :presence => true
-  validates :state, :presence => true
+  validates :title,
+            :presence => true
+
+  validates :state,
+            :presence => true
+
+  validates :root_content_item_id,
+            :presence => true
 
   ##
   # Callbacks

--- a/app/resources/topic_resource.rb
+++ b/app/resources/topic_resource.rb
@@ -10,6 +10,7 @@ class TopicResource < ApplicationResource
   attribute :title
   attribute :state
   attribute :description
+  attribute :root_content_item_id
 
   ##
   # Relationships
@@ -39,6 +40,10 @@ class TopicResource < ApplicationResource
   end
 
   def self.updatable_fields(context = {})
-    super(context) - %i[content collaborators assets conversations]
+    super(context) - %i[root_content_item_id content collaborators assets conversations]
+  end
+
+  def self.sortable_fields(context)
+    super(context) - %i[root_content_item_id]
   end
 end

--- a/config/locales/jsonapi.en.yml
+++ b/config/locales/jsonapi.en.yml
@@ -12,4 +12,16 @@ en:
         detail: "Your account has not been confirmed yet."
       unacceptable_version:
         title: "Unacceptable version"
-        detail: "The request cannot be fulfilled due to mismatching API version. The API version is '%{api_version}' This request specified '%{request_version}'."
+        detail: "The request cannot be fulfilled due to mismatching API version. The API version is '%{api_version}'. This request specified '%{request_version}'."
+      format:
+        title: "Invalid data format"
+        detail: "The data in the content structure must be valid."
+      invalid_root_content_item:
+        title: "Invalid root content item"
+        detail: "The identifier of the root content item must match the root content item of the topic."
+      no_root_content_item:
+        title: "No root content item"
+        detail: "The root content item was not found in the content structure."
+      incompatible_version:
+        title: "Invalid data format version"
+        detail: "The request cannot be fulfilled due to an incompatible repository data format version."

--- a/config/openwebslides.rb
+++ b/config/openwebslides.rb
@@ -72,5 +72,5 @@ OpenWebslides.configure do |config|
   ##
   # API version (semver)
   #
-  config.api.version = '3.0.0'
+  config.api.version = '4.0.0'
 end

--- a/config/openwebslides.rb
+++ b/config/openwebslides.rb
@@ -72,5 +72,8 @@ OpenWebslides.configure do |config|
   ##
   # API version (semver)
   #
+  # All requests with a version >= MAJOR.0 and < MAJOR.(MINOR + 1) will be processed
+  # For example, if the API version is 3.2.3, requests with version 3.0 up to < 3.3 will be processed
+  #
   config.api.version = '4.0.0'
 end

--- a/db/migrate/20180817072930_add_root_content_item_id_to_topic.rb
+++ b/db/migrate/20180817072930_add_root_content_item_id_to_topic.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRootContentItemIdToTopic < ActiveRecord::Migration[5.2]
+  def change
+    add_column :topics, :root_content_item_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_24_070926) do
+ActiveRecord::Schema.define(version: 2018_08_17_072930) do
 
   create_table "annotations", force: :cascade do |t|
     t.string "type"
@@ -83,6 +83,7 @@ ActiveRecord::Schema.define(version: 2018_07_24_070926) do
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "root_content_item_id"
     t.index ["user_id"], name: "index_topics_on_user_id"
   end
 

--- a/spec/acceptance/topic_spec.rb
+++ b/spec/acceptance/topic_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'Topic', :type => :request do
 
       headers = {
         'Content-Type' => 'application/vnd.api+json',
-        'Accept' => 'application/vnd.api+json, application/vnd.openwebslides+json; version=3.0.0',
+        'Accept' => "application/vnd.api+json, application/vnd.openwebslides+json; version=#{OpenWebslides.config.api.version}",
         'Authorization' => "Bearer #{JWT::Auth::Token.from_user(user).to_jwt}"
       }
 
@@ -108,7 +108,7 @@ RSpec.describe 'Topic', :type => :request do
 
     it 'returns without any errors' do
       headers = {
-        'Accept' => 'application/vnd.api+json, application/vnd.openwebslides+json; version=3.0.0'
+        'Accept' => "application/vnd.api+json, application/vnd.openwebslides+json; version=#{OpenWebslides.config.api.version}"
       }
 
       get "/api/topics/#{topic.id}/content", :headers => headers
@@ -142,7 +142,7 @@ RSpec.describe 'Topic', :type => :request do
 
       headers = {
         'Content-Type' => 'application/vnd.api+json',
-        'Accept' => 'application/vnd.api+json, application/vnd.openwebslides+json; version=3.0.0',
+        'Accept' => "application/vnd.api+json, application/vnd.openwebslides+json; version=#{OpenWebslides.config.api.version}",
         'Authorization' => "Bearer #{JWT::Auth::Token.from_user(user).to_jwt}"
       }
 
@@ -171,7 +171,7 @@ RSpec.describe 'Topic', :type => :request do
     it 'returns without any errors' do
       headers = {
         'Content-Type' => 'application/vnd.api+json',
-        'Accept' => 'application/vnd.api+json, application/vnd.openwebslides+json; version=3.0.0',
+        'Accept' => "application/vnd.api+json, application/vnd.openwebslides+json; version=#{OpenWebslides.config.api.version}",
         'Authorization' => "Bearer #{JWT::Auth::Token.from_user(user).to_jwt}"
       }
 

--- a/spec/acceptance/topic_spec.rb
+++ b/spec/acceptance/topic_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Topic', :type => :request do
 
   let(:content) do
     root = {
-      'id' => 'qyrgv0bcd6',
+      'id' => topic.root_content_item_id,
       'type' => 'contentItemTypes/ROOT',
       'childItemIds' => ['ivks4jgtxr']
     }
@@ -93,7 +93,7 @@ RSpec.describe 'Topic', :type => :request do
   end
 
   describe 'A user can retrieve the contents of a topic' do
-    let(:topic) { create :topic }
+    let(:topic) { create :topic, :root_content_item_id => 'qyrgv0bcd6' }
 
     before :each do
       service = TopicService.new topic

--- a/spec/acceptance/topic_spec.rb
+++ b/spec/acceptance/topic_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe 'Topic', :type => :request do
           :attributes => {
             :title => title,
             :description => description,
-            :state => 'private_access'
+            :state => 'private_access',
+            :rootContentItemId => 'ivks4jgtxr'
           },
           :relationships => {
             :user => {
@@ -86,7 +87,8 @@ RSpec.describe 'Topic', :type => :request do
       data = JSON.parse(response.body)['data']
       expect(data['attributes']).to match 'title' => title,
                                           'description' => description,
-                                          'state' => 'private_access'
+                                          'state' => 'private_access',
+                                          'rootContentItemId' => 'ivks4jgtxr'
     end
   end
 

--- a/spec/commands/repository/filesystem/write_spec.rb
+++ b/spec/commands/repository/filesystem/write_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Repository::Filesystem::Write do
   ##
   # Test variables
   #
-  let(:topic) { create :topic }
+  let(:topic) { create :topic, :root_content_item_id => 'qyrgv0bcd6' }
 
   let(:content) do
     root = {
@@ -42,6 +42,14 @@ RSpec.describe Repository::Filesystem::Write do
     }
 
     [root, heading, paragraph]
+  end
+
+  let(:root_content_item) do
+    {
+      'id' => Faker::Lorem.words(3).join(''),
+      'type' => 'contentItemTypes/ROOT',
+      'childItemIds' => []
+    }
   end
 
   ##
@@ -78,6 +86,16 @@ RSpec.describe Repository::Filesystem::Write do
 
       content_item_ids = Dir[File.join subject.send(:content_path), '*.yml'].map { |f| File.basename f, '.yml' }
       expect(content_item_ids).to match_array %w[qyrgv0bcd6 ivks4jgtxr oswmjc09be]
+    end
+  end
+
+  describe '#validate_root_content_item_id' do
+    it 'raises an error when root content item id does not match the database' do
+      expect { subject.send :validate_root_content_item_id, root_content_item }.to raise_error OpenWebslides::FormatError
+    end
+
+    it 'returns when root content item id matches the database' do
+      expect { subject.send :validate_root_content_item_id, content.first }.not_to raise_error
     end
   end
 

--- a/spec/commands/repository/filesystem/write_spec.rb
+++ b/spec/commands/repository/filesystem/write_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Repository::Filesystem::Write do
   # Test variables
   #
   let(:topic) { create :topic, :root_content_item_id => 'qyrgv0bcd6' }
+  let(:other_topic) { create :topic }
 
   let(:content) do
     root = {
@@ -72,6 +73,18 @@ RSpec.describe Repository::Filesystem::Write do
       expect { subject.execute }.to raise_error OpenWebslides::ArgumentError
     end
 
+    it 'raises an error when root content item is not present' do
+      subject.content = content.drop 1
+
+      expect { subject.execute }.to raise_error OpenWebslides::NoRootContentItemError
+    end
+
+    it 'raises an error when root content item id does not match the database' do
+      subject.content = [root_content_item]
+
+      expect { subject.execute }.to raise_error OpenWebslides::InvalidRootContentItemError
+    end
+
     it 'writes the index file' do
       subject.content = content
       subject.execute
@@ -86,16 +99,6 @@ RSpec.describe Repository::Filesystem::Write do
 
       content_item_ids = Dir[File.join subject.send(:content_path), '*.yml'].map { |f| File.basename f, '.yml' }
       expect(content_item_ids).to match_array %w[qyrgv0bcd6 ivks4jgtxr oswmjc09be]
-    end
-  end
-
-  describe '#validate_root_content_item_id' do
-    it 'raises an error when root content item id does not match the database' do
-      expect { subject.send :validate_root_content_item_id, root_content_item }.to raise_error OpenWebslides::FormatError
-    end
-
-    it 'returns when root content item id matches the database' do
-      expect { subject.send :validate_root_content_item_id, content.first }.not_to raise_error
     end
   end
 

--- a/spec/commands/repository/filesystem/yaml_command_spec.rb
+++ b/spec/commands/repository/filesystem/yaml_command_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Repository::Filesystem::YAMLCommand do
       allow(File).to receive(:read)
         .and_return("version: #{incompatible_version}")
 
-      expect { subject.send :validate_version }.to raise_error OpenWebslides::FormatError
+      expect { subject.send :validate_version }.to raise_error OpenWebslides::IncompatibleVersionError
     end
   end
 

--- a/spec/controllers/concerns/versioning_spec.rb
+++ b/spec/controllers/concerns/versioning_spec.rb
@@ -11,6 +11,16 @@ RSpec.describe UsersController do
       request.headers['Accept'] = accept_header
     end
 
+    describe 'malformed header' do
+      let(:accept_header) { 'foobar' }
+
+      it 'returns a 406' do
+        get :index
+
+        expect(response.status).to eq 406
+      end
+    end
+
     describe 'no header' do
       let(:accept_header) { '' }
 
@@ -71,6 +81,36 @@ RSpec.describe UsersController do
       get :index
 
       expect(response.headers['Content-Type']).to eq "application/vnd.api+json, application/vnd.openwebslides+json; version=#{OpenWebslides.config.api.version}"
+    end
+  end
+
+  describe '#compatible_request_version?' do
+    before :each do
+      allow(OpenWebslides.config.api).to receive(:version).and_return '2.5.3'
+    end
+
+    it 'is compatible when server is the same version as the request' do
+      expect(subject.send :compatible_request_version?, '2.5.3').to eq true
+    end
+
+    it 'is compatible when server is a bit newer than request, and request is backwards compatible' do
+      expect(subject.send :compatible_request_version?, '2.5.1').to eq true
+      expect(subject.send :compatible_request_version?, '2.4.8').to eq true
+    end
+
+    it 'is compatible when server is a lot newer than request, and request is backwards compatible' do
+      expect(subject.send :compatible_request_version?, '2.2.6').to eq true
+      expect(subject.send :compatible_request_version?, '2.0.0').to eq true
+    end
+
+    it 'is not compatible when server is a newer than request, and request is not backwards compatible' do
+      expect(subject.send :compatible_request_version?, '1.7.8').to eq false
+      expect(subject.send :compatible_request_version?, '0.0.1').to eq false
+    end
+
+    it 'is not compatible when server is older than request' do
+      expect(subject.send :compatible_request_version?, '2.6.2').to eq false
+      expect(subject.send :compatible_request_version?, '3.1.4').to eq false
     end
   end
 end

--- a/spec/factories/topic_factory.rb
+++ b/spec/factories/topic_factory.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :topic do
     title { Faker::Lorem.words(4).join ' ' }
     description { Faker::Lorem.words(20).join ' ' }
+    root_content_item_id { Faker::Lorem.words(3).join '' }
     state :public_access
     user { build :user, :confirmed }
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -18,6 +18,9 @@ RSpec.describe Topic, :type => :model do
     it { is_expected.not_to allow_value(nil).for(:state) }
     it { is_expected.not_to allow_value('').for(:state) }
 
+    it { is_expected.not_to allow_value(nil).for(:root_content_item_id) }
+    it { is_expected.not_to allow_value('').for(:root_content_item_id) }
+
     it 'is invalid without attributes' do
       expect(subject).not_to be_valid
     end

--- a/spec/requests/topic_spec.rb
+++ b/spec/requests/topic_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe 'Topic API', :type => :request do
     {
       :title => title,
       :state => %i[public_access protected_access private_access].sample,
-      :description => Faker::Lorem.words(20).join(' ')
+      :description => Faker::Lorem.words(20).join(' '),
+      :rootContentItemId => Faker::Lorem.words(3).join('')
     }
   end
 
@@ -164,10 +165,18 @@ RSpec.describe 'Topic API', :type => :request do
     end
 
     it 'rejects invalid state' do
-      patch topic_path(:id => topic.id), :params => update_body(topic.id, attributes.merge(:state => 'foo')), :headers => headers
+      patch topic_path(:id => topic.id), :params => update_body(topic.id, attributes.except(:rootContentItemId).merge(:state => 'foo')), :headers => headers
 
       expect(response.status).to eq 422
       expect(jsonapi_error_code(response)).to eq JSONAPI::VALIDATION_ERROR
+      expect(response.content_type).to eq "application/vnd.api+json, application/vnd.openwebslides+json; version=#{OpenWebslides.config.api.version}"
+    end
+
+    it 'rejects rootContentItemId changes' do
+      patch topic_path(:id => topic.id), :params => update_body(topic.id, attributes), :headers => headers
+
+      expect(response.status).to eq 400
+      expect(jsonapi_error_code(response)).to eq JSONAPI::PARAM_NOT_ALLOWED
       expect(response.content_type).to eq "application/vnd.api+json, application/vnd.openwebslides+json; version=#{OpenWebslides.config.api.version}"
     end
 

--- a/spec/resources/topic_resource_spec.rb
+++ b/spec/resources/topic_resource_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe TopicResource, :type => :resource do
 
   it { is_expected.to have_attribute :title }
   it { is_expected.to have_attribute :state }
+  it { is_expected.to have_attribute :root_content_item_id }
+  it { is_expected.to have_attribute :description }
 
   it { is_expected.to have_one :user }
   it { is_expected.to have_one :content }
@@ -24,16 +26,16 @@ RSpec.describe TopicResource, :type => :resource do
 
   describe 'fields' do
     it 'should have a valid set of fetchable fields' do
-      expect(subject.fetchable_fields).to match_array %i[id title state description user content collaborators assets conversations]
+      expect(subject.fetchable_fields).to match_array %i[id title state description root_content_item_id user content collaborators assets conversations]
     end
 
     it 'should omit empty fields' do
       subject { described_class.new nil_topic, context }
-      expect(subject.fetchable_fields).to match_array %i[id title state description user content collaborators assets conversations]
+      expect(subject.fetchable_fields).to match_array %i[id title state description root_content_item_id user content collaborators assets conversations]
     end
 
     it 'should have a valid set of creatable fields' do
-      expect(described_class.creatable_fields).to match_array %i[title state description user]
+      expect(described_class.creatable_fields).to match_array %i[title state description root_content_item_id user]
     end
 
     it 'should have a valid set of updatable fields' do


### PR DESCRIPTION
Add `rootContentItemId` to Topics API. This attribute is set upon creation and immutable.
When topic content is updated, the root content item in the request is validated against the database information.

Additionally, command and JSONAPI errors were rewritten to better reflect their purpose, and the versioning requirement for requests was loosened to allow minor versions lower than the server version.