### PR TITLE
Fork topic

### DIFF
--- a/app/commands/repository/filesystem/copy.rb
+++ b/app/commands/repository/filesystem/copy.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+module Repository
+  module Filesystem
+    ##
+    # Duplicate repository
+    #
+    class Copy < YAMLCommand
+      attr_accessor :fork
+
+      def execute
+        raise OpenWebslides::ArgumentError, 'No fork specified' unless @fork
+
+        # Create initial directory
+        raise OpenWebslides::RepoExistsError if Dir.exist? repo_path(@fork)
+        FileUtils.mkdir_p repo_path(@fork)
+
+        # Recursively copy repository
+        FileUtils.cp_r File.join(repo_path, '.'), repo_path(@fork)
+      end
+    end
+  end
+end

--- a/app/commands/repository/fork.rb
+++ b/app/commands/repository/fork.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Repository
+  ##
+  # Fork a repository in the backing store
+  #
+  class Fork < RepoCommand
+    attr_accessor :fork
+
+    def execute
+      raise OpenWebslides::ArgumentError, 'No fork specified' unless @fork
+
+      read_lock do
+        exec Filesystem::Copy do |c|
+          c.fork = @fork
+        end
+      end
+    end
+  end
+end

--- a/app/commands/repository/repo_command.rb
+++ b/app/commands/repository/repo_command.rb
@@ -7,8 +7,8 @@ module Repository
   class RepoCommand < Command
     protected
 
-    def repo_path
-      File.join OpenWebslides.config.repository.path, @receiver.user.id.to_s, @receiver.id.to_s
+    def repo_path(receiver = @receiver)
+      File.join OpenWebslides.config.repository.path, receiver.user.id.to_s, receiver.id.to_s
     end
 
     def lock_path

--- a/app/controllers/concerns/add_dummy_data.rb
+++ b/app/controllers/concerns/add_dummy_data.rb
@@ -3,6 +3,7 @@
 module AddDummyData
   extend ActiveSupport::Concern
 
+  ##
   # Add a dummy `id` attribute to the params, because JSONAPI::Resources does not officially
   # support singleton resources, and requires and `id` to be present when modifying these
   #
@@ -10,7 +11,8 @@ module AddDummyData
   ##
   # Prepend this action to the callback chain when creating a singleton:
   #
-  # prepend_before_action :add_dummy_create_id, :only => %i[update]
+  # prepend_before_action :add_dummy_create_id, :only => %i[create]
+  #
   def add_dummy_create_id
     params[:data] ||= {}
     params[:data][:id] ||= 0
@@ -20,6 +22,7 @@ module AddDummyData
   # Prepend this action to the callback chain when updating a singleton:
   #
   # prepend_before_action :add_dummy_update_id, :only => %i[update]
+  #
   def add_dummy_update_id
     add_dummy_create_id
   end
@@ -28,7 +31,23 @@ module AddDummyData
   # Prepend this action to the callback chain when destroying a singleton:
   #
   # prepend_before_action :add_dummy_destroy_id, :only => %i[destroy]
+  #
   def add_dummy_destroy_id
     params[:id] ||= 0
+  end
+
+  ##
+  # Add a `type` attribute to the params, because JSONAPI::Resources requires a type,
+  # even when handling POST resources without body
+  #
+
+  ##
+  # Prepend this action to the callback chain when creating a body-less resource:
+  #
+  # prepend_before_action :add_dummy_type, :only => %i[create]
+  #
+  def add_dummy_type
+    params[:data] ||= {}
+    params[:data][:type] = resource_klass._type.to_s
   end
 end

--- a/app/controllers/concerns/add_dummy_data.rb
+++ b/app/controllers/concerns/add_dummy_data.rb
@@ -1,6 +1,6 @@
 # frozen-string-literal: true
 
-module AddDummyId
+module AddDummyData
   extend ActiveSupport::Concern
 
   # Add a dummy `id` attribute to the params, because JSONAPI::Resources does not officially

--- a/app/controllers/concerns/add_dummy_id.rb
+++ b/app/controllers/concerns/add_dummy_id.rb
@@ -6,15 +6,26 @@ module AddDummyId
   # Add a dummy `id` attribute to the params, because JSONAPI::Resources does not officially
   # support singleton resources, and requires and `id` to be present when modifying these
   #
-  # Prepend this action to the callback chain:
+
+  ##
+  # Prepend this action to the callback chain when creating a singleton:
   #
-  # prepend_before_action :add_dummy_update_id, :only => %i[update]
-  def add_dummy_update_id
+  # prepend_before_action :add_dummy_create_id, :only => %i[update]
+  def add_dummy_create_id
     params[:data] ||= {}
     params[:data][:id] ||= 0
   end
 
-  # Prepend this action to the callback chain:
+  ##
+  # Prepend this action to the callback chain when updating a singleton:
+  #
+  # prepend_before_action :add_dummy_update_id, :only => %i[update]
+  def add_dummy_update_id
+    add_dummy_create_id
+  end
+
+  ##
+  # Prepend this action to the callback chain when destroying a singleton:
   #
   # prepend_before_action :add_dummy_destroy_id, :only => %i[destroy]
   def add_dummy_destroy_id

--- a/app/controllers/confirmation_controller.rb
+++ b/app/controllers/confirmation_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ConfirmationController < ApplicationController
-  include AddDummyId
+  include AddDummyData
 
   # Authorization
   after_action :verify_authorized

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -3,7 +3,7 @@
 class ContentController < ApplicationController
   include Relationships
   include RelatedResources
-  include AddDummyId
+  include AddDummyData
 
   # Authentication
   before_action :authenticate_user, :only => %i[update]

--- a/app/controllers/fork_controller.rb
+++ b/app/controllers/fork_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class ForkController < ApplicationController
+  include AddDummyData
+
+  # Authentication
+  before_action :authenticate_user
+  after_action :renew_token
+
+  # Authorization
+  after_action :verify_authorized
+
+  prepend_before_action :add_dummy_type, :only => %i[create]
+
+  ##
+  # Resource
+  #
+
+  # POST /fork
+  def create
+    @topic = Topic.find params[:topic_id]
+
+    authorize @topic, :fork?
+
+    @fork = @topic.dup
+
+    params = {
+      :author => current_user,
+      :fork => @fork
+    }
+
+    if service.fork params
+      jsonapi_render :json => @fork,
+                     :status => :created,
+                     :options => { :resource => TopicResource }
+    else
+      jsonapi_render_errors :json => @fork,
+                            :status => :unprocessable_entity
+    end
+  end
+
+  protected
+
+  def service
+    TopicService.new @topic
+  end
+end

--- a/app/controllers/password_controller.rb
+++ b/app/controllers/password_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PasswordController < ApplicationController
-  include AddDummyId
+  include AddDummyData
 
   # Authorization
   after_action :verify_authorized

--- a/app/controllers/rating_controller.rb
+++ b/app/controllers/rating_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class RatingController < ApplicationController
-  include AddDummyId
+  include AddDummyData
 
   # Authentication
   before_action :authenticate_user

--- a/app/controllers/token_controller.rb
+++ b/app/controllers/token_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TokenController < ApplicationController
-  include AddDummyId
+  include AddDummyData
 
   # Authentication
   before_action :authenticate_user, :only => :destroy

--- a/app/models/feed_item.rb
+++ b/app/models/feed_item.rb
@@ -7,7 +7,7 @@ class FeedItem < ApplicationRecord
   ##
   # Properties
   #
-  enum :event_type => %i[topic_created topic_updated]
+  enum :event_type => %i[topic_created topic_updated topic_forked]
 
   ##
   # Associations

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -26,6 +26,16 @@ class Topic < ApplicationRecord
   belongs_to :user,
              :inverse_of => :topics
 
+  belongs_to :upstream,
+             :optional => true,
+             :class_name => 'Topic',
+             :inverse_of => :forks
+
+  has_many :forks,
+           :class_name => 'Topic',
+           :foreign_key => :upstream_id,
+           :inverse_of => :upstream
+
   has_many :grants,
            :dependent => :destroy
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -74,6 +74,8 @@ class Topic < ApplicationRecord
 
   validate :upstream_cannot_be_fork
 
+  validate :upstream_xor_forks
+
   ##
   # Callbacks
   #
@@ -95,6 +97,15 @@ class Topic < ApplicationRecord
   # Helpers and callback methods
   #
   def upstream_cannot_be_fork
+    # If upstream is set, it cannot reference a topic that is a fork too (where upstream is non-empty)
     errors.add :upstream, 'cannot be a fork' if upstream&.upstream
+  end
+
+  def upstream_xor_forks
+    # Either `forks` or `upstream` can be set
+    return unless upstream && forks.any?
+
+    errors.add :upstream, 'cannot be non-empty when forks are specified'
+    errors.add :forks, 'cannot be non-empty when upstream is specified'
   end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -72,6 +72,8 @@ class Topic < ApplicationRecord
   validates :root_content_item_id,
             :presence => true
 
+  validate :upstream_cannot_be_fork
+
   ##
   # Callbacks
   #
@@ -92,4 +94,7 @@ class Topic < ApplicationRecord
   ##
   # Helpers and callback methods
   #
+  def upstream_cannot_be_fork
+    errors.add :upstream, 'cannot be a fork' if upstream&.upstream
+  end
 end

--- a/app/policies/topic_policy.rb
+++ b/app/policies/topic_policy.rb
@@ -55,6 +55,24 @@ class TopicPolicy < ApplicationPolicy
   end
 
   ##
+  # Relationship: upstream
+  #
+  def show_upstream?
+    # Users can only show upstream if the topic is showable
+    # Authorize the topic separately in the controller
+    show?
+  end
+
+  ##
+  # Relationship: forks
+  #
+  def show_forks?
+    # Users can only show forks if the topic is showable
+    # Policy scope separately in the controller
+    show?
+  end
+
+  ##
   # Relationship: collaborators
   #
   def show_collaborators?

--- a/app/policies/topic_policy.rb
+++ b/app/policies/topic_policy.rb
@@ -45,6 +45,13 @@ class TopicPolicy < ApplicationPolicy
     @record.user == @user
   end
 
+  def fork?
+    return false if @user.nil?
+
+    # User can only fork if the topic is showable
+    show?
+  end
+
   ##
   # Relationship: user
   #

--- a/app/resources/feed_item_resource.rb
+++ b/app/resources/feed_item_resource.rb
@@ -28,7 +28,7 @@ class FeedItemResource < ApplicationResource
   filter :user
   filter :topic
   filter :event_type,
-         :verify => ->(values, _) { values.map(&:downcase) & FeedItem.event_types.keys }
+         :verify => ->(values, _ = nil) { values.map(&:downcase) & FeedItem.event_types.keys }
 
   ##
   # Callbacks

--- a/app/resources/fork_resource.rb
+++ b/app/resources/fork_resource.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+##
+# Fork topic (abstract)
+#
+class ForkResource < ApplicationResource
+  abstract
+
+  ##
+  # Attributes
+  #
+  ##
+  # Relationships
+  #
+  ##
+  # Filters
+  #
+  ##
+  # Callbacks
+  #
+  ##
+  # Methods
+  #
+end

--- a/app/resources/topic_resource.rb
+++ b/app/resources/topic_resource.rb
@@ -18,6 +18,8 @@ class TopicResource < ApplicationResource
   has_one :user
   has_one :upstream
   has_one :content
+
+  has_many :forks
   has_many :collaborators
   has_many :assets
   has_many :conversations
@@ -37,11 +39,11 @@ class TopicResource < ApplicationResource
   # Methods
   #
   def self.creatable_fields(context = {})
-    super(context) - %i[upstream content collaborators assets conversations]
+    super(context) - %i[upstream content forks collaborators assets conversations]
   end
 
   def self.updatable_fields(context = {})
-    super(context) - %i[upstream root_content_item_id content collaborators assets conversations]
+    super(context) - %i[upstream root_content_item_id content forks collaborators assets conversations]
   end
 
   def self.sortable_fields(context)

--- a/app/resources/topic_resource.rb
+++ b/app/resources/topic_resource.rb
@@ -16,6 +16,7 @@ class TopicResource < ApplicationResource
   # Relationships
   #
   has_one :user
+  has_one :upstream
   has_one :content
   has_many :collaborators
   has_many :assets
@@ -36,11 +37,11 @@ class TopicResource < ApplicationResource
   # Methods
   #
   def self.creatable_fields(context = {})
-    super(context) - %i[content collaborators assets conversations]
+    super(context) - %i[upstream content collaborators assets conversations]
   end
 
   def self.updatable_fields(context = {})
-    super(context) - %i[root_content_item_id content collaborators assets conversations]
+    super(context) - %i[upstream root_content_item_id content collaborators assets conversations]
   end
 
   def self.sortable_fields(context)

--- a/app/services/topic_service.rb
+++ b/app/services/topic_service.rb
@@ -83,8 +83,7 @@ class TopicService < ApplicationService
   # WARNING: @topic contains the _original_ topic in this context
   #
   def fork(params)
-    # Duplicate topic
-    fork = @topic.dup
+    fork = params[:fork]
 
     # Set new attributes: author and upstream topic
     fork.user = params[:author]
@@ -98,9 +97,10 @@ class TopicService < ApplicationService
       command.fork = fork
 
       command.execute
-    end
 
-    # Return fork, with or without errors
-    fork
+      true
+    else
+      false
+    end
   end
 end

--- a/app/services/topic_service.rb
+++ b/app/services/topic_service.rb
@@ -98,10 +98,9 @@ class TopicService < ApplicationService
       command.fork = fork
 
       command.execute
-
-      fork
-    else
-      false
     end
+
+    # Return fork, with or without errors
+    fork
   end
 end

--- a/app/services/topic_service.rb
+++ b/app/services/topic_service.rb
@@ -7,9 +7,16 @@ class TopicService < ApplicationService
     @topic = topic
   end
 
+  ##
+  # Persist a newly built topic to the database and the filesystem
+  #
   def create
+    # Persist to database
     if @topic.save
+      # Persist to file system
       Repository::Create.new(@topic).execute
+
+      # Create feed item
       FeedItem.create :user => @topic.user,
                       :topic => @topic,
                       :event_type => :topic_created
@@ -20,10 +27,16 @@ class TopicService < ApplicationService
     end
   end
 
+  ##
+  # Read the filesystem contents of a topic
+  #
   def read
     Repository::Read.new(@topic).execute
   end
 
+  ##
+  # Update the filesystem contents of a topic
+  #
   def update(params)
     # Update database
     updatable_params = params.select do |k|
@@ -53,6 +66,9 @@ class TopicService < ApplicationService
     true
   end
 
+  ##
+  # Delete a topic from the database and the filesystem
+  #
   def delete
     # Delete repository
     Repository::Delete.new(@topic).execute

--- a/app/services/topic_service.rb
+++ b/app/services/topic_service.rb
@@ -76,4 +76,32 @@ class TopicService < ApplicationService
     # Delete database
     @topic.destroy
   end
+
+  ##
+  # Duplicate (fork) a topic in the database and the filesystem
+  #
+  # WARNING: @topic contains the _original_ topic in this context
+  #
+  def fork(params)
+    # Duplicate topic
+    fork = @topic.dup
+
+    # Set new attributes: author and upstream topic
+    fork.user = params[:author]
+    fork.upstream = @topic
+
+    # Persist to database
+    if fork.save
+      # Fork repository in filesystem
+      command = Repository::Fork.new @topic
+
+      command.fork = fork
+
+      command.execute
+
+      fork
+    else
+      false
+    end
+  end
 end

--- a/app/services/topic_service.rb
+++ b/app/services/topic_service.rb
@@ -98,6 +98,11 @@ class TopicService < ApplicationService
 
       command.execute
 
+      # Generate feed item
+      FeedItem.create :user => params[:author],
+                      :topic => @topic,
+                      :event_type => :topic_forked
+
       true
     else
       false

--- a/config/openwebslides.rb
+++ b/config/openwebslides.rb
@@ -75,5 +75,5 @@ OpenWebslides.configure do |config|
   # All requests with a version >= MAJOR.0 and < MAJOR.(MINOR + 1) will be processed
   # For example, if the API version is 3.2.3, requests with version 3.0 up to < 3.3 will be processed
   #
-  config.api.version = '4.0.0'
+  config.api.version = '4.1.0'
 end

--- a/config/openwebslides.rb
+++ b/config/openwebslides.rb
@@ -75,5 +75,5 @@ OpenWebslides.configure do |config|
   # All requests with a version >= MAJOR.0 and < MAJOR.(MINOR + 1) will be processed
   # For example, if the API version is 3.2.3, requests with version 3.0 up to < 3.3 will be processed
   #
-  config.api.version = '4.1.0'
+  config.api.version = '5.0.0'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,14 @@ Rails.application.routes.draw do
       jsonapi_related_resource :user
       jsonapi_link :user, :only => :show
 
+      # Upstream relationship
+      jsonapi_related_resource :upstream
+      jsonapi_link :upstream, :only => :show
+
+      # Forks relationship
+      jsonapi_related_resources :forks
+      jsonapi_links :forks, :only => :show
+
       # Collaborators relationship
       jsonapi_related_resources :collaborators
       jsonapi_links :collaborators, :only => :show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,9 @@ Rails.application.routes.draw do
       jsonapi_resources :assets, :only => :create
 
       jsonapi_resource :content, :only => %i[show update]
+
+      # Fork
+      jsonapi_resource :fork, :only => %i[create] do end
     end
 
     ##

--- a/db/migrate/20181002080305_add_upstream_to_topic.rb
+++ b/db/migrate/20181002080305_add_upstream_to_topic.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddUpstreamToTopic < ActiveRecord::Migration[5.2]
+  def change
+    # add_reference :topics, :topics, :foreign_key => 'upstream_id'
+    # add_reference :topics, :upstream, :foreign_key => { :to_table => :topics }
+    add_reference :topics, :upstream, :references => :topics
+    # change_table :topics do |t|
+    #   t.references :upstream, :references => :topics
+    # end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_17_072930) do
+ActiveRecord::Schema.define(version: 2018_10_02_080305) do
 
   create_table "annotations", force: :cascade do |t|
     t.string "type"
@@ -84,6 +84,8 @@ ActiveRecord::Schema.define(version: 2018_08_17_072930) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "root_content_item_id"
+    t.integer "upstream_id"
+    t.index ["upstream_id"], name: "index_topics_on_upstream_id"
     t.index ["user_id"], name: "index_topics_on_user_id"
   end
 

--- a/spec/commands/repository/filesystem/copy_spec.rb
+++ b/spec/commands/repository/filesystem/copy_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Repository::Filesystem::Copy do
+  ##
+  # Configuration
+  #
+  before :each do
+    OpenWebslides.configure do |config|
+      ##
+      # Absolute path to persistent repository storage
+      #
+      config.repository.path = Dir.mktmpdir
+    end
+  end
+
+  ##
+  # Test variables
+  #
+  let(:topic) { create :topic }
+  let(:fork) { create :topic, :upstream => topic }
+
+  ##
+  # Test subject
+  #
+  let(:subject) { described_class.new topic }
+
+  ##
+  # Tests
+  #
+  describe '#execute' do
+    before :each do
+      # Make sure the topic repository is created
+      TopicService.new(topic).create
+    end
+
+    describe 'repository already exists' do
+      before do
+        # Create the fork repository as well
+        TopicService.new(fork).create
+      end
+
+      it 'raises a RepoExistsError' do
+        subject.fork = fork
+
+        expect { subject.execute }.to raise_error OpenWebslides::RepoExistsError
+      end
+    end
+
+    it 'raises an error when fork is not specified' do
+      expect { subject.execute }.to raise_error OpenWebslides::ArgumentError
+    end
+
+    it 'duplicates the repository' do
+      subject.fork = fork
+      subject.execute
+
+      upstream_content_file = File.join subject.send(:repo_path), 'content.yml'
+      downstream_content_file = File.join subject.send(:repo_path, fork), 'content.yml'
+
+      expect(File.exists? downstream_content_file).to be true
+      expect(FileUtils.compare_file upstream_content_file, downstream_content_file).to be true
+    end
+  end
+end

--- a/spec/commands/repository/fork_spec.rb
+++ b/spec/commands/repository/fork_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Repository::Fork do
+  ##
+  # Test variables
+  #
+  let(:topic) { create :topic }
+
+  let(:fs_copy_command) { double 'Repository::Filesystem::Copy' }
+
+  ##
+  # Test subject
+  #
+  let(:subject) { described_class.new topic }
+
+  ##
+  # Tests
+  #
+  describe '#execute' do
+    it 'raises ArgumentError when no fork is specified' do
+      expect { subject.execute }.to raise_error OpenWebslides::ArgumentError
+    end
+
+    it 'calls Filesystem::Copy with parameters' do
+      expect(Repository::Filesystem::Copy).to receive(:new)
+        .with(topic)
+        .and_return fs_copy_command
+      expect(fs_copy_command).to receive(:fork=).with 'fork'
+      expect(fs_copy_command).to receive :execute
+
+      subject.fork = 'fork'
+
+      subject.execute
+    end
+  end
+end

--- a/spec/commands/repository/repo_command_spec.rb
+++ b/spec/commands/repository/repo_command_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Repository::RepoCommand do
   # Test variables
   #
   let(:topic) { create :topic }
+  let(:topic2) { create :topic }
 
   ##
   # Test subject
@@ -17,8 +18,12 @@ RSpec.describe Repository::RepoCommand do
   # Tests
   #
   describe '#repo_path' do
-    it 'points to a valid repository path' do
+    it 'points to a valid repository path of the receiver' do
       expect(subject.send :repo_path).to eq File.join OpenWebslides.config.repository.path, topic.user.id.to_s, topic.id.to_s
+    end
+
+    it 'points to a valid repository path of another deck' do
+      expect(subject.send :repo_path, topic2).to eq File.join OpenWebslides.config.repository.path, topic2.user.id.to_s, topic2.id.to_s
     end
   end
 end

--- a/spec/models/feed_item_spec.rb
+++ b/spec/models/feed_item_spec.rb
@@ -4,8 +4,9 @@ require 'rails_helper'
 
 RSpec.describe FeedItem, :type => :model do
   describe 'attributes' do
-    it { is_expected.not_to allow_value(nil).for(:event_type) }
-    it { is_expected.not_to allow_value('').for(:event_type) }
+    it { is_expected.not_to allow_value(nil).for :event_type }
+    it { is_expected.not_to allow_value('').for :event_type }
+    it { is_expected.to allow_values(:topic_created, :topic_updated, :topic_forked).for :event_type }
 
     it 'is invalid without attributes' do
       expect(FeedItem.new).not_to be_valid
@@ -17,7 +18,7 @@ RSpec.describe FeedItem, :type => :model do
     end
 
     it 'has a valid :event_type enum' do
-      expect(%w[topic_created topic_updated]).to eq FeedItem.event_types.keys
+      expect(%w[topic_created topic_updated topic_forked]).to eq FeedItem.event_types.keys
     end
   end
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Topic, :type => :model do
   before :each do
     Stub::Command.create Repository::Create
     Stub::Command.create Repository::Update, %i[content= author= message=]
+    Stub::Command.create Repository::Fork, %i[author= fork=]
   end
 
   ##
@@ -64,6 +65,7 @@ RSpec.describe Topic, :type => :model do
     it { is_expected.to have_many(:annotations).dependent(:destroy).inverse_of(:topic) }
     it { is_expected.to have_many(:conversations).inverse_of(:topic) }
 
+    ## TODO: move this to topic acceptance spec
     it 'generates a feed_item on create' do
       count = FeedItem.count
 
@@ -75,6 +77,7 @@ RSpec.describe Topic, :type => :model do
       expect(FeedItem.last.topic).to eq d
     end
 
+    # TODO: move this to topic acceptance spec
     it 'generates a feed_item on update' do
       d = create :topic
 
@@ -84,6 +87,19 @@ RSpec.describe Topic, :type => :model do
 
       expect(FeedItem.count).to eq count + 1
       expect(FeedItem.last.event_type).to eq 'topic_updated'
+      expect(FeedItem.last.topic).to eq d
+    end
+
+    # TODO: move this to topic acceptance spec
+    it 'generates a feed_item on fork' do
+      d = create :topic
+
+      count = FeedItem.count
+
+      TopicService.new(d).fork :author => user, :fork => d.dup
+
+      expect(FeedItem.count).to eq count + 1
+      expect(FeedItem.last.event_type).to eq 'topic_forked'
       expect(FeedItem.last.topic).to eq d
     end
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -3,14 +3,31 @@
 require 'rails_helper'
 
 RSpec.describe Topic, :type => :model do
+  ##
+  # Configuration
+  #
+  ##
+  # Test variables
+  #
   let(:topic) { build :topic, :with_assets }
   let(:user) { build :user }
 
+  ##
+  # Test subject
+  #
+  subject { topic }
+
+  ##
+  # Stubs
+  #
   before :each do
     Stub::Command.create Repository::Create
     Stub::Command.create Repository::Update, %i[content= author= message=]
   end
 
+  ##
+  # Tests
+  #
   describe 'attributes' do
     it { is_expected.not_to allow_value(nil).for(:title) }
     it { is_expected.not_to allow_value('').for(:title) }
@@ -22,15 +39,13 @@ RSpec.describe Topic, :type => :model do
     it { is_expected.not_to allow_value('').for(:root_content_item_id) }
 
     it 'is invalid without attributes' do
-      expect(subject).not_to be_valid
+      expect(described_class.new).not_to be_valid
     end
 
-    it 'is valid with attributes' do
-      expect(topic).to be_valid
-    end
+    it { is_expected.to be_valid }
 
     it 'has a valid :status enum' do
-      expect(%w[public_access protected_access private_access]).to include topic.state
+      expect(%w[public_access protected_access private_access]).to include subject.state
     end
   end
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -36,6 +36,9 @@ RSpec.describe Topic, :type => :model do
 
   describe 'associations' do
     it { is_expected.to belong_to(:user).inverse_of(:topics) }
+    it { is_expected.to belong_to(:upstream).inverse_of(:forks) }
+
+    it { is_expected.to have_many(:forks).inverse_of(:upstream) }
     it { is_expected.to have_many(:grants).dependent(:destroy) }
     it { is_expected.to have_many(:collaborators).through(:grants).inverse_of(:collaborations) }
     it { is_expected.to have_many(:assets).dependent(:destroy).inverse_of(:topic) }
@@ -64,6 +67,26 @@ RSpec.describe Topic, :type => :model do
       expect(FeedItem.count).to eq count + 1
       expect(FeedItem.last.event_type).to eq 'topic_updated'
       expect(FeedItem.last.topic).to eq d
+    end
+
+    describe 'upstream and forks' do
+      let(:upstream) { create :topic }
+      let(:topic) { create :topic, :upstream => upstream }
+      let(:topic2) { create :topic, :upstream => upstream }
+
+      it 'has an upstream' do
+        expect(topic.upstream).to eq upstream
+        expect(topic2.upstream).to eq upstream
+
+        expect(upstream.upstream).to be_nil
+      end
+
+      it 'has forks' do
+        expect(topic.forks).to be_empty
+        expect(topic2.forks).to be_empty
+
+        expect(upstream.forks).to include topic, topic2
+      end
     end
   end
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -102,6 +102,12 @@ RSpec.describe Topic, :type => :model do
 
         expect(upstream.forks).to include topic, topic2
       end
+
+      describe 'cannot be a fork of a fork' do
+        let(:topic) { build :topic, :upstream => topic2 }
+
+        it { is_expected.not_to be_valid }
+      end
     end
   end
 

--- a/spec/policies/topic_policy_spec.rb
+++ b/spec/policies/topic_policy_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe TopicPolicy do
         expect(subject).to permit_action :show
         expect(subject).to forbid_action :update
         expect(subject).to forbid_action :destroy
+        expect(subject).to forbid_action :fork
 
         expect(subject).to permit_action :show_user
         expect(subject).to permit_action :show_upstream
@@ -41,6 +42,7 @@ RSpec.describe TopicPolicy do
         expect(subject).to forbid_action :show
         expect(subject).to forbid_action :update
         expect(subject).to forbid_action :destroy
+        expect(subject).to forbid_action :fork
 
         expect(subject).to forbid_action :show_user
         expect(subject).to forbid_action :show_upstream
@@ -59,6 +61,7 @@ RSpec.describe TopicPolicy do
         expect(subject).to forbid_action :show
         expect(subject).to forbid_action :update
         expect(subject).to forbid_action :destroy
+        expect(subject).to forbid_action :fork
 
         expect(subject).to forbid_action :show_user
         expect(subject).to forbid_action :show_upstream
@@ -88,6 +91,7 @@ RSpec.describe TopicPolicy do
         expect(subject).to permit_action :show
         expect(subject).to forbid_action :update
         expect(subject).to forbid_action :destroy
+        expect(subject).to permit_action :fork
 
         expect(subject).to permit_action :show_user
         expect(subject).to permit_action :show_upstream
@@ -106,6 +110,7 @@ RSpec.describe TopicPolicy do
         expect(subject).to permit_action :show
         expect(subject).to forbid_action :update
         expect(subject).to forbid_action :destroy
+        expect(subject).to permit_action :fork
 
         expect(subject).to permit_action :show_user
         expect(subject).to permit_action :show_upstream
@@ -124,6 +129,7 @@ RSpec.describe TopicPolicy do
         expect(subject).to forbid_action :show
         expect(subject).to forbid_action :update
         expect(subject).to forbid_action :destroy
+        expect(subject).to forbid_action :fork
 
         expect(subject).to forbid_action :show_user
         expect(subject).to forbid_action :show_upstream
@@ -154,6 +160,7 @@ RSpec.describe TopicPolicy do
         expect(subject).to permit_action :show
         expect(subject).to permit_action :update
         expect(subject).to forbid_action :destroy
+        expect(subject).to permit_action :fork
 
         expect(subject).to permit_action :show_user
         expect(subject).to permit_action :show_upstream
@@ -173,6 +180,7 @@ RSpec.describe TopicPolicy do
         expect(subject).to permit_action :show
         expect(subject).to permit_action :update
         expect(subject).to forbid_action :destroy
+        expect(subject).to permit_action :fork
 
         expect(subject).to permit_action :show_user
         expect(subject).to permit_action :show_upstream
@@ -192,6 +200,7 @@ RSpec.describe TopicPolicy do
         expect(subject).to permit_action :show
         expect(subject).to permit_action :update
         expect(subject).to forbid_action :destroy
+        expect(subject).to permit_action :fork
 
         expect(subject).to permit_action :show_user
         expect(subject).to permit_action :show_upstream
@@ -205,7 +214,7 @@ RSpec.describe TopicPolicy do
     end
   end
 
-  context 'for a user' do
+  context 'for an owner' do
     let(:user) { build :user, :with_topics }
 
     it { is_expected.to permit_action :index }
@@ -222,6 +231,7 @@ RSpec.describe TopicPolicy do
         expect(subject).to permit_action :show
         expect(subject).to permit_action :update
         expect(subject).to permit_action :destroy
+        expect(subject).to permit_action :fork
 
         expect(subject).to permit_action :show_user
         expect(subject).to permit_action :show_upstream
@@ -241,6 +251,7 @@ RSpec.describe TopicPolicy do
         expect(subject).to permit_action :show
         expect(subject).to permit_action :update
         expect(subject).to permit_action :destroy
+        expect(subject).to permit_action :fork
 
         expect(subject).to permit_action :show_user
         expect(subject).to permit_action :show_upstream
@@ -260,6 +271,7 @@ RSpec.describe TopicPolicy do
         expect(subject).to permit_action :show
         expect(subject).to permit_action :update
         expect(subject).to permit_action :destroy
+        expect(subject).to permit_action :fork
 
         expect(subject).to permit_action :show_user
         expect(subject).to permit_action :show_upstream

--- a/spec/policies/topic_policy_spec.rb
+++ b/spec/policies/topic_policy_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to forbid_action :destroy
 
         expect(subject).to permit_action :show_user
+        expect(subject).to permit_action :show_upstream
+        expect(subject).to permit_action :show_forks
         expect(subject).to permit_action :show_collaborators
         expect(subject).to permit_action :show_assets
         expect(subject).to permit_action :show_feed_items
@@ -41,6 +43,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to forbid_action :destroy
 
         expect(subject).to forbid_action :show_user
+        expect(subject).to forbid_action :show_upstream
+        expect(subject).to forbid_action :show_forks
         expect(subject).to forbid_action :show_collaborators
         expect(subject).to forbid_action :show_assets
         expect(subject).to forbid_action :show_feed_items
@@ -57,6 +61,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to forbid_action :destroy
 
         expect(subject).to forbid_action :show_user
+        expect(subject).to forbid_action :show_upstream
+        expect(subject).to forbid_action :show_forks
         expect(subject).to forbid_action :show_collaborators
         expect(subject).to forbid_action :show_assets
         expect(subject).to forbid_action :show_feed_items
@@ -84,6 +90,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to forbid_action :destroy
 
         expect(subject).to permit_action :show_user
+        expect(subject).to permit_action :show_upstream
+        expect(subject).to permit_action :show_forks
         expect(subject).to permit_action :show_collaborators
         expect(subject).to permit_action :show_assets
         expect(subject).to permit_action :show_feed_items
@@ -100,6 +108,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to forbid_action :destroy
 
         expect(subject).to permit_action :show_user
+        expect(subject).to permit_action :show_upstream
+        expect(subject).to permit_action :show_forks
         expect(subject).to permit_action :show_collaborators
         expect(subject).to permit_action :show_assets
         expect(subject).to permit_action :show_feed_items
@@ -116,6 +126,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to forbid_action :destroy
 
         expect(subject).to forbid_action :show_user
+        expect(subject).to forbid_action :show_upstream
+        expect(subject).to forbid_action :show_forks
         expect(subject).to forbid_action :show_collaborators
         expect(subject).to forbid_action :show_assets
         expect(subject).to forbid_action :show_feed_items
@@ -144,6 +156,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to forbid_action :destroy
 
         expect(subject).to permit_action :show_user
+        expect(subject).to permit_action :show_upstream
+        expect(subject).to permit_action :show_forks
         expect(subject).to permit_action :show_collaborators
         expect(subject).to permit_action :show_assets
         expect(subject).to permit_action :show_feed_items
@@ -161,6 +175,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to forbid_action :destroy
 
         expect(subject).to permit_action :show_user
+        expect(subject).to permit_action :show_upstream
+        expect(subject).to permit_action :show_forks
         expect(subject).to permit_action :show_collaborators
         expect(subject).to permit_action :show_assets
         expect(subject).to permit_action :show_feed_items
@@ -178,6 +194,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to forbid_action :destroy
 
         expect(subject).to permit_action :show_user
+        expect(subject).to permit_action :show_upstream
+        expect(subject).to permit_action :show_forks
         expect(subject).to permit_action :show_collaborators
         expect(subject).to permit_action :show_assets
         expect(subject).to permit_action :show_feed_items
@@ -206,6 +224,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to permit_action :destroy
 
         expect(subject).to permit_action :show_user
+        expect(subject).to permit_action :show_upstream
+        expect(subject).to permit_action :show_forks
         expect(subject).to permit_action :show_collaborators
         expect(subject).to permit_action :show_assets
         expect(subject).to permit_action :show_feed_items
@@ -223,6 +243,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to permit_action :destroy
 
         expect(subject).to permit_action :show_user
+        expect(subject).to permit_action :show_upstream
+        expect(subject).to permit_action :show_forks
         expect(subject).to permit_action :show_collaborators
         expect(subject).to permit_action :show_assets
         expect(subject).to permit_action :show_feed_items
@@ -240,6 +262,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to permit_action :destroy
 
         expect(subject).to permit_action :show_user
+        expect(subject).to permit_action :show_upstream
+        expect(subject).to permit_action :show_forks
         expect(subject).to permit_action :show_collaborators
         expect(subject).to permit_action :show_assets
         expect(subject).to permit_action :show_feed_items

--- a/spec/resources/feed_item_resource_spec.rb
+++ b/spec/resources/feed_item_resource_spec.rb
@@ -38,5 +38,13 @@ RSpec.describe FeedItemResource, :type => :resource do
     it 'should have a valid set of filters' do
       expect(described_class.filters.keys).to match_array %i[id event_type topic user]
     end
+
+    describe 'event_type#verify' do
+      subject { described_class.filters[:event_type][:verify] }
+
+      it 'filters the right event types' do
+        expect(subject.call %w[topic_created foobar topic_updated topic_forked TOPIC_CREATED TOPIC_UPDATED TOPIC_FORKED FOO FOOBAR]).to match_array %w[topic_created topic_updated topic_forked]
+      end
+    end
   end
 end

--- a/spec/resources/fork_resource_spec.rb
+++ b/spec/resources/fork_resource_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ForkResource, :type => :resource do
+  describe 'fields' do
+    it 'should have a valid set of creatable fields' do
+      expect(described_class.creatable_fields).to be_empty
+    end
+  end
+end

--- a/spec/resources/topic_resource_spec.rb
+++ b/spec/resources/topic_resource_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe TopicResource, :type => :resource do
   it { is_expected.to have_attribute :description }
 
   it { is_expected.to have_one :user }
+  it { is_expected.to have_one :upstream }
   it { is_expected.to have_one :content }
 
   it { is_expected.to have_many(:collaborators).with_class_name 'User' }
@@ -26,12 +27,12 @@ RSpec.describe TopicResource, :type => :resource do
 
   describe 'fields' do
     it 'should have a valid set of fetchable fields' do
-      expect(subject.fetchable_fields).to match_array %i[id title state description root_content_item_id user content collaborators assets conversations]
+      expect(subject.fetchable_fields).to match_array %i[id title state description root_content_item_id user upstream content collaborators assets conversations]
     end
 
     it 'should omit empty fields' do
       subject { described_class.new nil_topic, context }
-      expect(subject.fetchable_fields).to match_array %i[id title state description root_content_item_id user content collaborators assets conversations]
+      expect(subject.fetchable_fields).to match_array %i[id title state description root_content_item_id user upstream content collaborators assets conversations]
     end
 
     it 'should have a valid set of creatable fields' do

--- a/spec/resources/topic_resource_spec.rb
+++ b/spec/resources/topic_resource_spec.rb
@@ -22,17 +22,18 @@ RSpec.describe TopicResource, :type => :resource do
   it { is_expected.to have_one :content }
 
   it { is_expected.to have_many(:collaborators).with_class_name 'User' }
+  it { is_expected.to have_many(:forks).with_class_name 'Topic' }
   it { is_expected.to have_many(:assets) }
   it { is_expected.to have_many(:conversations) }
 
   describe 'fields' do
     it 'should have a valid set of fetchable fields' do
-      expect(subject.fetchable_fields).to match_array %i[id title state description root_content_item_id user upstream content collaborators assets conversations]
+      expect(subject.fetchable_fields).to match_array %i[id title state description root_content_item_id user upstream content forks collaborators assets conversations]
     end
 
     it 'should omit empty fields' do
       subject { described_class.new nil_topic, context }
-      expect(subject.fetchable_fields).to match_array %i[id title state description root_content_item_id user upstream content collaborators assets conversations]
+      expect(subject.fetchable_fields).to match_array %i[id title state description root_content_item_id user upstream content forks collaborators assets conversations]
     end
 
     it 'should have a valid set of creatable fields' do

--- a/spec/routing/fork_routing_spec.rb
+++ b/spec/routing/fork_routing_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'fork routing', :type => :routing do
+  it 'routes topics fork endpoint' do
+    route = '/api/topics/foo/fork'
+
+    expect(:get => route).not_to be_routable
+    expect(:post => route).to route_to 'fork#create', :topic_id => 'foo'
+    expect(:patch => route).not_to be_routable
+    expect(:put => route).not_to be_routable
+    expect(:delete => route).not_to be_routable
+  end
+end

--- a/spec/routing/topics_routing_spec.rb
+++ b/spec/routing/topics_routing_spec.rb
@@ -36,6 +36,32 @@ RSpec.describe 'topics routing', :type => :routing do
     expect(:delete => route).not_to be_routable
   end
 
+  it 'routes topic upstream relationship endpoint' do
+    route = '/api/topics/foo/relationships/upstream'
+    params = { :topic_id => 'foo', :relationship => 'upstream' }
+
+    expect(:get => '/api/topics/foo/upstream').to route_to 'topics#get_related_resource', params.merge(:source => 'topics')
+
+    expect(:get => route).to route_to 'topics#show_relationship', params
+    expect(:patch => route).not_to be_routable
+    expect(:put => route).not_to be_routable
+    expect(:post => route).not_to be_routable
+    expect(:delete => route).not_to be_routable
+  end
+
+  it 'routes topic forks relationship endpoint' do
+    route = '/api/topics/foo/relationships/forks'
+    params = { :topic_id => 'foo', :relationship => 'forks' }
+
+    expect(:get => '/api/topics/foo/forks').to route_to 'topics#get_related_resources', params.merge(:source => 'topics')
+
+    expect(:get => route).to route_to 'topics#show_relationship', params
+    expect(:patch => route).not_to be_routable
+    expect(:put => route).not_to be_routable
+    expect(:post => route).not_to be_routable
+    expect(:delete => route).not_to be_routable
+  end
+
   it 'routes topic collaborators relationship endpoint' do
     route = '/api/topics/foo/relationships/collaborators'
     params = { :topic_id => 'foo', :relationship => 'collaborators' }

--- a/spec/services/topic_service_spec.rb
+++ b/spec/services/topic_service_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe TopicService do
   # Test variables
   #
   let(:topic) { create :topic }
+  let(:fork) { create :topic, :upstream => topic }
   let(:user) { create :user }
 
   let(:fork_command) { double 'Repository::Fork' }
@@ -25,8 +26,22 @@ RSpec.describe TopicService do
   ##
   # Tests
   #
-  describe 'fork' do
-    it 'forks the topic' do
+  describe '#fork' do
+    describe 'upstream is a fork' do
+      subject { described_class.new fork }
+
+      it 'returns fork with errors' do
+        fork = subject.fork :author => user
+
+        expect(fork).not_to be_nil
+        expect(fork).to be_a Topic
+        expect(fork).not_to be_persisted
+        expect(fork).not_to be_valid
+        expect(fork.errors).not_to be_empty
+      end
+    end
+
+    it 'returns fork' do
       expect(Repository::Fork).to receive(:new)
         .with(topic)
         .and_return fork_command

--- a/spec/services/topic_service_spec.rb
+++ b/spec/services/topic_service_spec.rb
@@ -30,33 +30,36 @@ RSpec.describe TopicService do
     describe 'upstream is a fork' do
       subject { described_class.new fork }
 
-      it 'returns fork with errors' do
-        fork = subject.fork :author => user
+      it 'returns false' do
+        new_fork = topic.dup
+        result = subject.fork :author => user, :fork => new_fork
 
-        expect(fork).not_to be_nil
-        expect(fork).to be_a Topic
-        expect(fork).not_to be_persisted
-        expect(fork).not_to be_valid
-        expect(fork.errors).not_to be_empty
+        expect(result).to be false
+
+        expect(new_fork).not_to be_persisted
+        expect(new_fork).not_to be_valid
+        expect(new_fork.errors).not_to be_empty
       end
     end
 
     it 'returns fork' do
+      new_fork = topic.dup
+
       expect(Repository::Fork).to receive(:new)
         .with(topic)
         .and_return fork_command
       expect(fork_command).to receive(:fork=)
       expect(fork_command).to receive :execute
 
-      fork = subject.fork :author => user
+      result = subject.fork :author => user, :fork => new_fork
 
-      expect(fork).not_to be_nil
-      expect(fork).to be_a Topic
-      expect(fork).to be_persisted
-      expect(fork).to be_valid
+      expect(result).to be true
 
-      expect(fork.upstream).to eq topic
-      expect(fork.user).to eq user
+      expect(new_fork).to be_persisted
+      expect(new_fork).to be_valid
+
+      expect(new_fork.upstream).to eq topic
+      expect(new_fork.user).to eq user
     end
   end
 end

--- a/spec/services/topic_service_spec.rb
+++ b/spec/services/topic_service_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TopicService do
+  ##
+  # Configuration
+  #
+  ##
+  # Test variables
+  #
+  let(:topic) { create :topic }
+  let(:user) { create :user }
+
+  let(:fork_command) { double 'Repository::Fork' }
+
+  ##
+  # Subject
+  #
+  subject { described_class.new topic }
+
+  ##
+  # Stubs and mocks
+  #
+  ##
+  # Tests
+  #
+  describe 'fork' do
+    it 'forks the topic' do
+      expect(Repository::Fork).to receive(:new)
+        .with(topic)
+        .and_return fork_command
+      expect(fork_command).to receive(:fork=)
+      expect(fork_command).to receive :execute
+
+      fork = subject.fork :author => user
+
+      expect(fork).not_to be_nil
+      expect(fork).to be_a Topic
+      expect(fork).to be_persisted
+      expect(fork).to be_valid
+
+      expect(fork.upstream).to eq topic
+      expect(fork.user).to eq user
+    end
+  end
+end

--- a/spec/services/topic_service_spec.rb
+++ b/spec/services/topic_service_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe TopicService do
   let(:user) { create :user }
 
   let(:fork_command) { double 'Repository::Fork' }
+  let(:feed_item_class) { double 'FeedItem' }
 
   ##
   # Subject
@@ -50,6 +51,10 @@ RSpec.describe TopicService do
         .and_return fork_command
       expect(fork_command).to receive(:fork=)
       expect(fork_command).to receive :execute
+
+      expect(FeedItem).to receive(:create)
+        .with(hash_including(:user => user, :topic => topic, :event_type => :topic_forked))
+        .and_return feed_item_class
 
       result = subject.fork :author => user, :fork => new_fork
 


### PR DESCRIPTION
Add ability to fork topic

- `POST /topics/:id/fork` creates a duplicate of the topic under the current user's account
- Topics can only be forked once - forks of a fork are not allowed

See changelog in [documentation](https://openwebslides.github.io/documentation/) for more details