### PR TITLE
Pull Request API

### DIFF
--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -17,7 +17,7 @@ class AlertsController < ApplicationController
   # Resource
   #
 
-  # GET /topics/:id
+  # GET /alerts/:id
   def show
     @alert = Alert.find params[:id]
 

--- a/app/controllers/feed_items_controller.rb
+++ b/app/controllers/feed_items_controller.rb
@@ -12,7 +12,7 @@ class FeedItemsController < ApplicationController
   # Resource
   #
 
-  # GET /feed_items
+  # GET /feedItems
   def index
     @feed_items = policy_scope FeedItem
 

--- a/app/controllers/pull_requests_controller.rb
+++ b/app/controllers/pull_requests_controller.rb
@@ -30,6 +30,8 @@ class PullRequestsController < ApplicationController
   def create
     @pull_request = PullRequest.new pull_request_params
 
+    # TODO: validate if the source topic is up to date with the target topic
+
     authorize @pull_request
 
     if @pull_request.save

--- a/app/controllers/pull_requests_controller.rb
+++ b/app/controllers/pull_requests_controller.rb
@@ -26,9 +26,30 @@ class PullRequestsController < ApplicationController
     jsonapi_render :json => @pull_request
   end
 
+  # POST /pullRequests
+  def create
+    @pull_request = PullRequest.new pull_request_params
+
+    authorize @pull_request
+
+    if @pull_request.save
+      jsonapi_render :json => @pull_request, :status => :created
+    else
+      jsonapi_render_errors :json => @pull_request, :status => :unprocessable_entity
+    end
+  end
+
   ##
   # Relationships
   #
   # Relationships and related resource actions are implemented in the respective concerns
   #
+
+  protected
+
+  def pull_request_params
+    resource_params.merge :user_id => relationship_params[:user],
+                          :source_id => relationship_params[:source],
+                          :target_id => relationship_params[:target]
+  end
 end

--- a/app/controllers/pull_requests_controller.rb
+++ b/app/controllers/pull_requests_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class PullRequestsController < ApplicationController
+  include Relationships
+  include RelatedResources
+
+  # Authentication
+  before_action :authenticate_user, :only => %i[show]
+  after_action :renew_token
+
+  # Authorization
+  after_action :verify_authorized, :except => %i[show_relationship get_related_resources]
+  after_action :verify_policy_scoped, :only => %i[get_related_resources]
+  after_action :verify_authorized_or_policy_scoped, :only => :show_relationship
+
+  ##
+  # Resource
+  #
+
+  # GET /pullRequests/:id
+  def show
+    @pull_request = PullRequest.find params[:id]
+
+    authorize @pull_request
+
+    jsonapi_render :json => @pull_request
+  end
+
+  ##
+  # Relationships
+  #
+  # Relationships and related resource actions are implemented in the respective concerns
+  #
+end

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -24,15 +24,6 @@ class Annotation < ApplicationRecord
            :inverse_of => :annotation
 
   ##
-  # Validations
-  #
-  validates :content_item_id,
-            :presence => true
-
-  validates :state,
-            :presence => true
-
-  ##
   # State
   #
   state_machine :initial => :created do
@@ -73,6 +64,15 @@ class Annotation < ApplicationRecord
       transition :secret => :created
     end
   end
+
+  ##
+  # Validations
+  #
+  validates :content_item_id,
+            :presence => true
+
+  validates :state,
+            :presence => true
 
   ##
   # Callbacks

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -56,6 +56,8 @@ class PullRequest < ApplicationRecord
 
   validate :target_is_upstream_source
 
+  validate :source_has_one_open_pr
+
   ##
   # Callbacks
   #
@@ -76,5 +78,11 @@ class PullRequest < ApplicationRecord
     return if source.upstream == target
 
     errors.add :source, I18n.t('openwebslides.validations.pull_request.target_is_upstream_source')
+  end
+
+  def source_has_one_open_pr
+    return unless source.outgoing_pull_requests.any?(&:open?)
+
+    errors.add :source, I18n.t('openwebslides.validations.pull_request.source_has_one_open_pr')
   end
 end

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+##
+# A request to merge a topic into another topic
+#
+class PullRequest < ApplicationRecord
+  ##
+  # Properties
+  #
+
+  # Message from the user who submitted the pull request
+  property :message
+
+  # Message from the user who accepted/rejected the pull request
+  property :feedback
+
+  ##
+  # Associations
+  #
+  belongs_to :user
+
+  # Topic that will be merged from
+  belongs_to :source,
+             :class_name => 'Topic',
+             :inverse_of => :outgoing_pull_requests
+
+  # Topic that will be merge into
+  belongs_to :target,
+             :class_name => 'Topic',
+             :inverse_of => :incoming_pull_requests
+
+  ##
+  # State
+  #
+  state_machine :initial => :open do
+    state :open, :value => 0
+    state :accepted, :value => 1
+    state :rejected, :value => 2
+
+    # Accept/approve a pull request
+    event :accept do
+      transition :open => :accepted
+    end
+
+    # Reject a pull request
+    event :reject do
+      transition :open => :rejected
+    end
+  end
+
+  ##
+  # Validations
+  #
+  validates :message,
+            :presence => true
+
+  ##
+  # Callbacks
+  #
+  ##
+  # Methods
+  #
+  def closed?
+    accepted? || rejected?
+  end
+
+  ##
+  # Overrides
+  #
+  ##
+  # Helpers and callback methods
+  #
+end

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -54,6 +54,8 @@ class PullRequest < ApplicationRecord
   validates :message,
             :presence => true
 
+  validate :target_is_upstream_source
+
   ##
   # Callbacks
   #
@@ -70,4 +72,9 @@ class PullRequest < ApplicationRecord
   ##
   # Helpers and callback methods
   #
+  def target_is_upstream_source
+    return if source.upstream == target
+
+    errors.add :source, I18n.t('openwebslides.validations.pull_request.target_is_upstream_source')
+  end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -60,6 +60,18 @@ class Topic < ApplicationRecord
   has_many :conversations,
            :inverse_of => :topic
 
+  has_many :incoming_pull_requests,
+           :class_name => 'PullRequest',
+           :foreign_key => :target_id,
+           :dependent => :destroy,
+           :inverse_of => :target
+
+  has_many :outgoing_pull_requests,
+           :class_name => 'PullRequest',
+           :foreign_key => :source_id,
+           :dependent => :destroy,
+           :inverse_of => :source
+
   ##
   # Validations
   #

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -94,6 +94,12 @@ class Topic < ApplicationRecord
   ##
   # Methods
   #
+
+  # Find open outgoing pull request
+  def pull_request
+    outgoing_pull_requests.find(&:open?)
+  end
+
   ##
   # Overrides
   #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -113,13 +113,13 @@ class User < ApplicationRecord
   # Helpers and callback methods
   #
   def readonly_email
-    errors.add :email, 'cannot be changed' if email_changed?
+    errors.add :email, I18n.t('openwebslides.validations.user.readonly_email') if email_changed?
   end
 
   def accepted_terms
     return if tos_accepted?
 
-    errors.add :tos_accepted, I18n.t('openwebslides.validations.user.tos_accepted')
+    errors.add :tos_accepted, I18n.t('openwebslides.validations.user.accepted_terms')
   end
 
   private

--- a/app/policies/pull_request_policy.rb
+++ b/app/policies/pull_request_policy.rb
@@ -10,8 +10,8 @@ class PullRequestPolicy < ApplicationPolicy
     # Users can create a pull request but only for itself
     return false unless @record.user == @user
 
-    # Users can show if the source is updatable
-    source_policy.update?
+    # Users can show if the source is updatable and the target is showable
+    source_policy.update? && target_policy.show?
   end
 
   def show?

--- a/app/policies/pull_request_policy.rb
+++ b/app/policies/pull_request_policy.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+class PullRequestPolicy < ApplicationPolicy
+  ##
+  # Resource
+  #
+  def show?
+    return false if @user.nil?
+
+    # Users can show if the source or the target is updatable
+    source_policy.update? || target_policy.update?
+  end
+
+  ##
+  # Relationship: user
+  #
+  def show_user?
+    # Users can only show user if the pull request is showable
+    # Authorize the user separately in the controller
+    show?
+  end
+
+  ##
+  # Relationship: source
+  #
+  def show_source?
+    # Users can only show source if the pull request is showable
+    # Authorize the source separately in the controller
+    show?
+  end
+
+  ##
+  # Relationship: target
+  #
+  def show_target?
+    # Users can only show target if the pull request is showable
+    # Authorize the target separately in the controller
+    show?
+  end
+
+  ##
+  # Scope
+  #
+  class Scope < Scope
+    def resolve
+      return scope.none unless @user
+
+      # Users can see pull requests of updatable source and target topics
+      source_query = 'source.user_id = ? OR source_grants.user_id = ?'
+      target_query = 'target.user_id = ? OR target_grants.user_id = ?'
+      query = "#{source_query} OR #{target_query}"
+
+      scope.joins('INNER JOIN topics source ON source.id = pull_requests.source_id')
+           .joins('INNER JOIN topics target ON target.id = pull_requests.target_id')
+           .joins('LEFT OUTER JOIN grants source_grants ON source_grants.topic_id = source.id')
+           .joins('LEFT OUTER JOIN grants target_grants ON target_grants.topic_id = target.id')
+           .where(query, @user.id, @user.id, @user.id, @user.id)
+           .distinct
+    end
+  end
+
+  private
+
+  def source_policy
+    @source_policy ||= Pundit.policy! @user, @record.source
+  end
+
+  def target_policy
+    @target_policy ||= Pundit.policy! @user, @record.target
+  end
+end

--- a/app/policies/pull_request_policy.rb
+++ b/app/policies/pull_request_policy.rb
@@ -4,6 +4,16 @@ class PullRequestPolicy < ApplicationPolicy
   ##
   # Resource
   #
+  def create?
+    return false if @user.nil?
+
+    # Users can create a pull request but only for itself
+    return false unless @record.user == @user
+
+    # Users can show if the source is updatable
+    source_policy.update?
+  end
+
   def show?
     return false if @user.nil?
 

--- a/app/policies/topic_policy.rb
+++ b/app/policies/topic_policy.rb
@@ -126,6 +126,24 @@ class TopicPolicy < ApplicationPolicy
   end
 
   ##
+  # Relationships: incoming_pull_requests
+  #
+  def show_incoming_pull_requests?
+    # Users can show incoming pull requests relationship if the topic is updatable
+    # Policy scope the pull requests separately in the controller
+    update?
+  end
+
+  ##
+  # Relationships: outgoing_pull_requests
+  #
+  def show_outgoing_pull_requests?
+    # Users can show outgoing pull requests relationship if the topic is updatable
+    # Policy scope the pull requests separately in the controller
+    update?
+  end
+
+  ##
   # Scope
   #
   class Scope < Scope

--- a/app/resources/pull_request_resource.rb
+++ b/app/resources/pull_request_resource.rb
@@ -45,4 +45,9 @@ class PullRequestResource < ApplicationResource
       options[:serializer].key_formatter.format(:created_at) => DateValueFormatter.format(_model.created_at)
     }
   end
+
+  # Override state to show the state name instead of the identifier
+  def state
+    _model.state_name.to_s
+  end
 end

--- a/app/resources/pull_request_resource.rb
+++ b/app/resources/pull_request_resource.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+##
+# Pull request resource
+#
+class PullRequestResource < ApplicationResource
+  immutable
+
+  ##
+  # Attributes
+  #
+  attribute :message
+  attribute :feedback
+  attribute :state
+
+  ##
+  # Relationships
+  #
+  has_one :user
+  has_one :source
+  has_one :target
+
+  ##
+  # Filters
+  #
+  filter :state,
+         :verify => ->(values, _) { values & PullRequest.state_machine.states.map { |s| s.name.to_s } }
+
+  ##
+  # Callbacks
+  #
+  ##
+  # Methods
+  #
+  def self.creatable_fields(context = {})
+    super(context) - %i[feedback state]
+  end
+
+  def self.sortable_fields(context)
+    super(context) - %i[message feedback]
+  end
+
+  def meta(options)
+    {
+      options[:serializer].key_formatter.format(:created_at) => DateValueFormatter.format(_model.created_at)
+    }
+  end
+end

--- a/app/resources/topic_resource.rb
+++ b/app/resources/topic_resource.rb
@@ -23,6 +23,8 @@ class TopicResource < ApplicationResource
   has_many :collaborators
   has_many :assets
   has_many :conversations
+  has_many :incoming_pull_requests
+  has_many :outgoing_pull_requests
 
   ##
   # Filters
@@ -39,11 +41,17 @@ class TopicResource < ApplicationResource
   # Methods
   #
   def self.creatable_fields(context = {})
-    super(context) - %i[upstream content forks collaborators assets conversations]
+    super(context) - %i[
+      upstream content forks collaborators assets conversations
+      incoming_pull_requests outgoing_pull_requests
+    ]
   end
 
   def self.updatable_fields(context = {})
-    super(context) - %i[upstream root_content_item_id content forks collaborators assets conversations]
+    super(context) - %i[
+      upstream root_content_item_id content forks collaborators assets conversations
+      incoming_pull_requests outgoing_pull_requests
+    ]
   end
 
   def self.sortable_fields(context)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,7 @@ en:
         accepted_terms: "must be true"
       pull_request:
         target_is_upstream_source: "must have target as upstream"
+        source_has_one_open_pr: "can only have on open pull request"
     annotations:
       hidden: "[deleted]"
     mailer:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,7 +27,8 @@ en:
         detail: "Repository exists"
     validations:
       user:
-        tos_accepted: "must be true"
+        readonly_email: "cannot be changed"
+        accepted_terms: "must be true"
     annotations:
       hidden: "[deleted]"
     mailer:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,8 @@ en:
       user:
         readonly_email: "cannot be changed"
         accepted_terms: "must be true"
+      pull_request:
+        target_is_upstream_source: "must have target as upstream"
     annotations:
       hidden: "[deleted]"
     mailer:

--- a/config/openwebslides.rb
+++ b/config/openwebslides.rb
@@ -75,5 +75,5 @@ OpenWebslides.configure do |config|
   # All requests with a version >= MAJOR.0 and < MAJOR.(MINOR + 1) will be processed
   # For example, if the API version is 3.2.3, requests with version 3.0 up to < 3.3 will be processed
   #
-  config.api.version = '5.1.0'
+  config.api.version = '5.2.0'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,12 +77,37 @@ Rails.application.routes.draw do
       jsonapi_related_resources :conversations
       jsonapi_links :conversations, :only => :show
 
+      # Incoming pull requests relationship
+      jsonapi_related_resources :incoming_pull_requests
+      jsonapi_links :incoming_pull_requests, :only => :show
+
+      # Outgoing pull requests relationship
+      jsonapi_related_resources :outgoing_pull_requests
+      jsonapi_links :outgoing_pull_requests, :only => :show
+
       jsonapi_resources :assets, :only => :create
 
       jsonapi_resource :content, :only => %i[show update]
 
       # Fork
       jsonapi_resource :fork, :only => %i[create] do end
+    end
+
+    ##
+    # Pull Requests API
+    #
+    jsonapi_resources :pull_requests, :only => %i[show] do
+      # User relationship
+      jsonapi_related_resource :user
+      jsonapi_link :user, :only => :show
+
+      # Source relationship
+      jsonapi_related_resource :source
+      jsonapi_link :source, :only => :show
+
+      # Target relationship
+      jsonapi_related_resource :target
+      jsonapi_link :target, :only => :show
     end
 
     ##

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,7 +96,7 @@ Rails.application.routes.draw do
     ##
     # Pull Requests API
     #
-    jsonapi_resources :pull_requests, :only => %i[show] do
+    jsonapi_resources :pull_requests, :only => %i[create show] do
       # User relationship
       jsonapi_related_resource :user
       jsonapi_link :user, :only => :show

--- a/db/migrate/20181112113733_add_pull_requests.rb
+++ b/db/migrate/20181112113733_add_pull_requests.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddPullRequests < ActiveRecord::Migration[5.2]
+  def change
+    create_table :pull_requests do |t|
+      t.string :message, :null => false, :default => ''
+      t.string :feedback
+      t.integer :state
+
+      t.references :user, :foreign_key => true
+      t.references :source, :references => :topic
+      t.references :target, :references => :topic
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_07_203146) do
+ActiveRecord::Schema.define(version: 2018_11_12_113733) do
 
   create_table "alerts", force: :cascade do |t|
     t.integer "user_id"
@@ -77,6 +77,20 @@ ActiveRecord::Schema.define(version: 2018_11_07_203146) do
     t.datetime "updated_at", null: false
     t.index ["uid", "provider"], name: "index_identities_on_uid_and_provider", unique: true
     t.index ["user_id"], name: "index_identities_on_user_id"
+  end
+
+  create_table "pull_requests", force: :cascade do |t|
+    t.string "message", default: "", null: false
+    t.string "feedback"
+    t.integer "state"
+    t.integer "user_id"
+    t.integer "source_id"
+    t.integer "target_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["source_id"], name: "index_pull_requests_on_source_id"
+    t.index ["target_id"], name: "index_pull_requests_on_target_id"
+    t.index ["user_id"], name: "index_pull_requests_on_user_id"
   end
 
   create_table "ratings", force: :cascade do |t|

--- a/spec/factories/pull_request_factory.rb
+++ b/spec/factories/pull_request_factory.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :pull_request do
+    message { Faker::Lorem.words(20).join ' ' }
+
+    user { build :user, :confirmed }
+    source { build :topic, :upstream => target }
+    target { build :topic }
+  end
+end

--- a/spec/factories/pull_request_factory.rb
+++ b/spec/factories/pull_request_factory.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :pull_request do
     message { Faker::Lorem.words(20).join ' ' }
+    feedback { Faker::Lorem.words(20).join ' ' }
 
     user { build :user, :confirmed }
     source { build :topic, :upstream => target }

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PullRequest, :type => :model do
+  ##
+  # Configuration
+  #
+  ##
+  # Stubs and mocks
+  #
+  ##
+  # Test variables
+  #
+  let(:subject) { create :pull_request }
+
+  ##
+  # Tests
+  #
+  it { is_expected.to be_valid }
+
+  describe 'attributes' do
+    it { is_expected.to validate_presence_of(:message) }
+
+    it { is_expected.to allow_values(nil, '', 'foo').for(:feedback) }
+  end
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:source).class_name('Topic').inverse_of(:outgoing_pull_requests) }
+    it { is_expected.to belong_to(:target).class_name('Topic').inverse_of(:incoming_pull_requests) }
+  end
+
+  describe 'state machine' do
+    it { is_expected.to have_states :open, :accepted, :rejected }
+
+    context 'when the pull request is open' do
+      it { is_expected.to handle_events :accept, :reject, :when => :open }
+
+      it { is_expected.to transition_from :open, :to_state => :accepted, :on_event => :accept }
+      it { is_expected.to transition_from :open, :to_state => :rejected, :on_event => :reject }
+    end
+
+    context 'when the pull request is accepted' do
+      it { is_expected.to reject_events :accept, :reject, :when => :accepted }
+    end
+
+    context 'when the pull request is rejected' do
+      it { is_expected.to reject_events :accept, :reject, :when => :rejected }
+    end
+  end
+
+  describe 'methods' do
+    describe '#closed?' do
+      context 'when the pull request is open' do
+        it { is_expected.not_to be_closed }
+      end
+
+      context 'when the pull request is accepted' do
+        before { subject.accept }
+        it { is_expected.to be_closed }
+      end
+
+      context 'when the pull request is rejected' do
+        before { subject.reject }
+        it { is_expected.to be_closed }
+      end
+    end
+  end
+end

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -29,6 +29,28 @@ RSpec.describe PullRequest, :type => :model do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:source).class_name('Topic').inverse_of(:outgoing_pull_requests) }
     it { is_expected.to belong_to(:target).class_name('Topic').inverse_of(:incoming_pull_requests) }
+
+    context 'when source does not have an upstream' do
+      let(:subject) { build :pull_request, :source => build(:topic) }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when source has an upstream not equal to the target' do
+      let(:subject) { build :pull_request, :source => build(:topic, :upstream => create(:topic)) }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when source already has an open pull request' do
+      let(:pull_request) { create :pull_request }
+      let(:subject) { build :pull_request, :source => pull_request.source, :target => pull_request.target }
+
+      # Reload source topic to refetch associations
+      before { pull_request.source.reload }
+
+      it { is_expected.not_to be_valid }
+    end
   end
 
   describe 'state machine' do

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -209,5 +209,31 @@ RSpec.describe Topic, :type => :model do
       expect(topic).to respond_to :content
       expect(topic).to respond_to :content_id
     end
+
+    describe '#pull_request' do
+      let(:open_pr) { create :pull_request, :source => downstream, :target => upstream }
+
+      before do
+        create(:pull_request, :source => downstream, :target => upstream).reject
+        create(:pull_request, :source => downstream, :target => upstream).accept
+      end
+
+      context 'when there is an open pull request' do
+        it 'returns the only open outgoing pull request' do
+          # Reload objects to refetch associations
+          open_pr.reload
+          downstream.reload
+
+          expect(downstream.pull_request).to eq open_pr
+        end
+      end
+
+      context 'when this is no open pull request' do
+        it 'returns nil' do
+          # Don't reload objects
+          expect(downstream.pull_request).to be_nil
+        end
+      end
+    end
   end
 end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -64,6 +64,8 @@ RSpec.describe Topic, :type => :model do
     it { is_expected.to have_many(:feed_items).dependent(:destroy).inverse_of(:topic) }
     it { is_expected.to have_many(:annotations).dependent(:destroy).inverse_of(:topic) }
     it { is_expected.to have_many(:conversations).inverse_of(:topic) }
+    it { is_expected.to have_many(:incoming_pull_requests).class_name('PullRequest').dependent(:destroy).inverse_of(:target) }
+    it { is_expected.to have_many(:outgoing_pull_requests).class_name('PullRequest').dependent(:destroy).inverse_of(:source) }
 
     ## TODO: move this to topic acceptance spec
     it 'generates a feed_item on create' do

--- a/spec/policies/alert_policy_scope_spec.rb
+++ b/spec/policies/alert_policy_scope_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe AlertPolicy::Scope do
   end
 
   context 'when the user is a user' do
-    let(:user) { nil }
+    let(:user) { create :user }
 
     it { is_expected.to eq 0 }
   end

--- a/spec/policies/pull_request_policy_scope_spec.rb
+++ b/spec/policies/pull_request_policy_scope_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PullRequestPolicy::Scope do
+  subject { described_class.new(user, PullRequest).resolve.count }
+
+  let(:pr_user) { create :user, :confirmed }
+
+  let(:source) { create :topic, :upstream => target }
+  let(:target) { create :topic }
+
+  before do
+    create(:pull_request, :user => pr_user, :source => source, :target => target).reject
+    create(:pull_request, :user => pr_user, :source => source, :target => target).accept
+    create(:pull_request, :user => pr_user, :source => source, :target => target)
+  end
+
+  context 'when the user is a guest' do
+    let(:user) { nil }
+
+    it { is_expected.to eq 0 }
+  end
+
+  context 'when the user is a user' do
+    let(:user) { create :user }
+
+    it { is_expected.to eq 0 }
+
+    context 'when the source is updatable' do
+      before { source.collaborators << user }
+
+      it { is_expected.to eq 3 }
+    end
+
+    context 'when the target is updatable' do
+      before { target.collaborators << user }
+
+      it { is_expected.to eq 3 }
+    end
+  end
+
+  context 'when the user is the same' do
+    let(:user) { pr_user }
+
+    it { is_expected.to eq 0 }
+
+    context 'when the source is updatable' do
+      before { source.collaborators << user }
+
+      it { is_expected.to eq 3 }
+    end
+
+    context 'when the target is updatable' do
+      before { target.collaborators << user }
+
+      it { is_expected.to eq 3 }
+    end
+  end
+end

--- a/spec/policies/pull_request_policy_spec.rb
+++ b/spec/policies/pull_request_policy_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe PullRequestPolicy do
     let(:user) { nil }
 
     it { is_expected.to forbid_action :show }
+    it { is_expected.to forbid_action :create }
 
     it { is_expected.to forbid_action :show_user }
     it { is_expected.to forbid_action :show_source }
@@ -21,6 +22,7 @@ RSpec.describe PullRequestPolicy do
     let(:user) { build :user }
 
     it { is_expected.to forbid_action :show }
+    it { is_expected.to forbid_action :create }
 
     it { is_expected.to forbid_action :show_user }
     it { is_expected.to forbid_action :show_source }
@@ -30,6 +32,7 @@ RSpec.describe PullRequestPolicy do
       before { record.source.collaborators << user }
 
       it { is_expected.to permit_action :show }
+      it { is_expected.to forbid_action :create }
 
       it { is_expected.to permit_action :show_user }
       it { is_expected.to permit_action :show_source }
@@ -37,9 +40,10 @@ RSpec.describe PullRequestPolicy do
     end
 
     context 'when the target is updatable' do
-      before { record.source.collaborators << user }
+      before { record.target.collaborators << user }
 
       it { is_expected.to permit_action :show }
+      it { is_expected.to forbid_action :create }
 
       it { is_expected.to permit_action :show_user }
       it { is_expected.to permit_action :show_source }
@@ -51,6 +55,7 @@ RSpec.describe PullRequestPolicy do
     let(:user) { record.user }
 
     it { is_expected.to forbid_action :show }
+    it { is_expected.to forbid_action :create }
 
     it { is_expected.to forbid_action :show_user }
     it { is_expected.to forbid_action :show_source }
@@ -60,6 +65,7 @@ RSpec.describe PullRequestPolicy do
       before { record.source.collaborators << user }
 
       it { is_expected.to permit_action :show }
+      it { is_expected.to permit_action :create }
 
       it { is_expected.to permit_action :show_user }
       it { is_expected.to permit_action :show_source }
@@ -67,9 +73,10 @@ RSpec.describe PullRequestPolicy do
     end
 
     context 'when the target is updatable' do
-      before { record.source.collaborators << user }
+      before { record.target.collaborators << user }
 
       it { is_expected.to permit_action :show }
+      it { is_expected.to forbid_action :create }
 
       it { is_expected.to permit_action :show_user }
       it { is_expected.to permit_action :show_source }

--- a/spec/policies/pull_request_policy_spec.rb
+++ b/spec/policies/pull_request_policy_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PullRequestPolicy do
+  subject { described_class.new user, record }
+
+  let(:record) { create :pull_request }
+
+  context 'when the user is a guest' do
+    let(:user) { nil }
+
+    it { is_expected.to forbid_action :show }
+
+    it { is_expected.to forbid_action :show_user }
+    it { is_expected.to forbid_action :show_source }
+    it { is_expected.to forbid_action :show_target }
+  end
+
+  context 'when the user is a user' do
+    let(:user) { build :user }
+
+    it { is_expected.to forbid_action :show }
+
+    it { is_expected.to forbid_action :show_user }
+    it { is_expected.to forbid_action :show_source }
+    it { is_expected.to forbid_action :show_target }
+
+    context 'when the source is updatable' do
+      before { record.source.collaborators << user }
+
+      it { is_expected.to permit_action :show }
+
+      it { is_expected.to permit_action :show_user }
+      it { is_expected.to permit_action :show_source }
+      it { is_expected.to permit_action :show_target }
+    end
+
+    context 'when the target is updatable' do
+      before { record.source.collaborators << user }
+
+      it { is_expected.to permit_action :show }
+
+      it { is_expected.to permit_action :show_user }
+      it { is_expected.to permit_action :show_source }
+      it { is_expected.to permit_action :show_target }
+    end
+  end
+
+  context 'when the user is the same' do
+    let(:user) { record.user }
+
+    it { is_expected.to forbid_action :show }
+
+    it { is_expected.to forbid_action :show_user }
+    it { is_expected.to forbid_action :show_source }
+    it { is_expected.to forbid_action :show_target }
+
+    context 'when the source is updatable' do
+      before { record.source.collaborators << user }
+
+      it { is_expected.to permit_action :show }
+
+      it { is_expected.to permit_action :show_user }
+      it { is_expected.to permit_action :show_source }
+      it { is_expected.to permit_action :show_target }
+    end
+
+    context 'when the target is updatable' do
+      before { record.source.collaborators << user }
+
+      it { is_expected.to permit_action :show }
+
+      it { is_expected.to permit_action :show_user }
+      it { is_expected.to permit_action :show_source }
+      it { is_expected.to permit_action :show_target }
+    end
+  end
+end

--- a/spec/policies/pull_request_policy_spec.rb
+++ b/spec/policies/pull_request_policy_spec.rb
@@ -65,11 +65,20 @@ RSpec.describe PullRequestPolicy do
       before { record.source.collaborators << user }
 
       it { is_expected.to permit_action :show }
-      it { is_expected.to permit_action :create }
 
       it { is_expected.to permit_action :show_user }
       it { is_expected.to permit_action :show_source }
       it { is_expected.to permit_action :show_target }
+
+      context 'when the target is showable' do
+        it { is_expected.to permit_action :create }
+      end
+
+      context 'when the target is not showable' do
+        before { record.target.update :state => :private_access }
+
+        it { is_expected.to forbid_action :create }
+      end
     end
 
     context 'when the target is updatable' do

--- a/spec/policies/topic_policy_spec.rb
+++ b/spec/policies/topic_policy_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to permit_action :show_feed_items
         expect(subject).to permit_action :show_conversations
         expect(subject).to permit_action :show_annotations
+        expect(subject).to forbid_action :show_incoming_pull_requests
+        expect(subject).to forbid_action :show_outgoing_pull_requests
       end
     end
 
@@ -52,6 +54,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to forbid_action :show_feed_items
         expect(subject).to forbid_action :show_conversations
         expect(subject).to forbid_action :show_annotations
+        expect(subject).to forbid_action :show_incoming_pull_requests
+        expect(subject).to forbid_action :show_outgoing_pull_requests
       end
     end
 
@@ -71,6 +75,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to forbid_action :show_feed_items
         expect(subject).to forbid_action :show_conversations
         expect(subject).to forbid_action :show_annotations
+        expect(subject).to forbid_action :show_incoming_pull_requests
+        expect(subject).to forbid_action :show_outgoing_pull_requests
       end
     end
   end
@@ -101,6 +107,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to permit_action :show_feed_items
         expect(subject).to permit_action :show_conversations
         expect(subject).to permit_action :show_annotations
+        expect(subject).to forbid_action :show_incoming_pull_requests
+        expect(subject).to forbid_action :show_outgoing_pull_requests
       end
     end
 
@@ -120,6 +128,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to permit_action :show_feed_items
         expect(subject).to permit_action :show_conversations
         expect(subject).to permit_action :show_annotations
+        expect(subject).to forbid_action :show_incoming_pull_requests
+        expect(subject).to forbid_action :show_outgoing_pull_requests
       end
     end
 
@@ -139,6 +149,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to forbid_action :show_feed_items
         expect(subject).to forbid_action :show_conversations
         expect(subject).to forbid_action :show_annotations
+        expect(subject).to forbid_action :show_incoming_pull_requests
+        expect(subject).to forbid_action :show_outgoing_pull_requests
       end
     end
   end
@@ -170,6 +182,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to permit_action :show_feed_items
         expect(subject).to permit_action :show_conversations
         expect(subject).to permit_action :show_annotations
+        expect(subject).to permit_action :show_incoming_pull_requests
+        expect(subject).to permit_action :show_outgoing_pull_requests
       end
     end
 
@@ -190,6 +204,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to permit_action :show_feed_items
         expect(subject).to permit_action :show_conversations
         expect(subject).to permit_action :show_annotations
+        expect(subject).to permit_action :show_incoming_pull_requests
+        expect(subject).to permit_action :show_outgoing_pull_requests
       end
     end
 
@@ -210,6 +226,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to permit_action :show_feed_items
         expect(subject).to permit_action :show_conversations
         expect(subject).to permit_action :show_annotations
+        expect(subject).to permit_action :show_incoming_pull_requests
+        expect(subject).to permit_action :show_outgoing_pull_requests
       end
     end
   end
@@ -241,6 +259,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to permit_action :show_feed_items
         expect(subject).to permit_action :show_conversations
         expect(subject).to permit_action :show_annotations
+        expect(subject).to permit_action :show_incoming_pull_requests
+        expect(subject).to permit_action :show_outgoing_pull_requests
       end
     end
 
@@ -261,6 +281,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to permit_action :show_feed_items
         expect(subject).to permit_action :show_conversations
         expect(subject).to permit_action :show_annotations
+        expect(subject).to permit_action :show_incoming_pull_requests
+        expect(subject).to permit_action :show_outgoing_pull_requests
       end
     end
 
@@ -281,6 +303,8 @@ RSpec.describe TopicPolicy do
         expect(subject).to permit_action :show_feed_items
         expect(subject).to permit_action :show_conversations
         expect(subject).to permit_action :show_annotations
+        expect(subject).to permit_action :show_incoming_pull_requests
+        expect(subject).to permit_action :show_outgoing_pull_requests
       end
     end
   end

--- a/spec/requests/pull_request_spec.rb
+++ b/spec/requests/pull_request_spec.rb
@@ -76,6 +76,30 @@ RSpec.describe 'Pull Request API', :type => :request do
       expect(response.content_type).to eq "application/vnd.api+json, application/vnd.openwebslides+json; version=#{OpenWebslides.config.api.version}"
     end
 
+    context 'when the source does not have an upstream' do
+      before { pull_request.source.update :upstream => nil }
+
+      it 'rejects' do
+        post pull_requests_path, :params => request_body(attributes), :headers => headers
+
+        expect(response.status).to eq 422
+        expect(jsonapi_error_code(response)).to eq JSONAPI::VALIDATION_ERROR
+        expect(response.content_type).to eq "application/vnd.api+json, application/vnd.openwebslides+json; version=#{OpenWebslides.config.api.version}"
+      end
+    end
+
+    context 'when the source has an upstream not equal to the target' do
+      before { pull_request.source.update :upstream => create(:topic) }
+
+      it 'rejects' do
+        post pull_requests_path, :params => request_body(attributes), :headers => headers
+
+        expect(response.status).to eq 422
+        expect(jsonapi_error_code(response)).to eq JSONAPI::VALIDATION_ERROR
+        expect(response.content_type).to eq "application/vnd.api+json, application/vnd.openwebslides+json; version=#{OpenWebslides.config.api.version}"
+      end
+    end
+
     it 'returns successful' do
       post pull_requests_path, :params => request_body(attributes), :headers => headers
 

--- a/spec/requests/pull_request_spec.rb
+++ b/spec/requests/pull_request_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Pull Request API', :type => :request do
+  ##
+  # Configuration
+  #
+  ##
+  # Stubs and mocks
+  #
+  ##
+  # Test variables
+  #
+  let(:pull_request) { create :pull_request }
+
+  let(:user) { create :user, :confirmed }
+
+  before do
+    pull_request.source.collaborators << user
+    pull_request.target.collaborators << user
+  end
+
+  ##
+  # Tests
+  #
+  describe 'GET /:id' do
+    before do
+      add_content_type_header
+      add_auth_header
+    end
+
+    it 'rejects an invalid id' do
+      get pull_request_path(:id => 0), :headers => headers
+
+      expect(response.status).to eq 404
+      expect(response.content_type).to eq "application/vnd.api+json, application/vnd.openwebslides+json; version=#{OpenWebslides.config.api.version}"
+    end
+
+    it 'returns successful' do
+      get pull_request_path(:id => pull_request.id), :headers => headers
+
+      expect(response.status).to eq 200
+      expect(response.content_type).to eq "application/vnd.api+json, application/vnd.openwebslides+json; version=#{OpenWebslides.config.api.version}"
+    end
+  end
+
+  describe 'GET /incomingPullRequests' do
+    before do
+      add_content_type_header
+      add_auth_header
+    end
+
+    it 'returns successful' do
+      get topic_incomingPullRequests_path(:topic_id => pull_request.target.id), :headers => headers
+
+      expect(response.status).to eq 200
+      expect(response.content_type).to eq "application/vnd.api+json, application/vnd.openwebslides+json; version=#{OpenWebslides.config.api.version}"
+
+      json = JSON.parse response.body
+      expect(json['data'].count).to eq 1
+    end
+  end
+
+  describe 'GET /outgoingPullRequests' do
+    before do
+      add_content_type_header
+      add_auth_header
+    end
+
+    it 'returns successful' do
+      get topic_outgoingPullRequests_path(:topic_id => pull_request.source.id), :headers => headers
+
+      expect(response.status).to eq 200
+      expect(response.content_type).to eq "application/vnd.api+json, application/vnd.openwebslides+json; version=#{OpenWebslides.config.api.version}"
+
+      json = JSON.parse response.body
+      expect(json['data'].count).to eq 1
+    end
+  end
+end

--- a/spec/resources/pull_request_resource_spec.rb
+++ b/spec/resources/pull_request_resource_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PullRequestResource, :type => :resource do
+  ##
+  # Configuration
+  #
+  ##
+  # Stubs and mocks
+  #
+  ##
+  # Test variables
+  #
+  let(:subject) { described_class.new pull_request, context }
+
+  let(:pull_request) { create :pull_request }
+  let(:context) { {} }
+
+  ##
+  # Tests
+  #
+  it { is_expected.to have_primary_key :id }
+
+  it { is_expected.to have_attribute :message }
+  it { is_expected.to have_attribute :feedback }
+  it { is_expected.to have_attribute :state }
+
+  it { is_expected.to be_immutable }
+
+  it { is_expected.to have_one :user }
+  it { is_expected.to have_one :source }
+  it { is_expected.to have_one :target }
+
+  it { is_expected.to respond_to :meta }
+
+  describe 'fields' do
+    it 'has a valid set of fetchable fields' do
+      expect(subject.fetchable_fields).to match_array %i[id message feedback state user source target]
+    end
+
+    it 'has a valid set of creatable fields' do
+      expect(described_class.creatable_fields).to match_array %i[message user source target]
+    end
+
+    it 'has a valid set of sortable fields' do
+      expect(described_class.sortable_fields context).to match_array %i[id state]
+    end
+  end
+
+  describe 'filters' do
+    it 'has a valid set of filters' do
+      expect(described_class.filters.keys).to match_array %i[id state]
+    end
+
+    let(:verify) { described_class.filters[:state][:verify] }
+
+    it 'should verify state' do
+      expect(verify.call(%w[open foo accepted bar rejected], {}))
+        .to match_array %w[open accepted rejected]
+    end
+  end
+end

--- a/spec/resources/pull_request_resource_spec.rb
+++ b/spec/resources/pull_request_resource_spec.rb
@@ -60,4 +60,30 @@ RSpec.describe PullRequestResource, :type => :resource do
         .to match_array %w[open accepted rejected]
     end
   end
+
+  describe 'methods' do
+    describe '#state' do
+      context 'when the pull request is open' do
+        it 'returns the state name' do
+          expect(subject.state).to eq 'open'
+        end
+      end
+
+      context 'when the pull request is accepted' do
+        before { pull_request.accept }
+
+        it 'returns the state name' do
+          expect(subject.state).to eq 'accepted'
+        end
+      end
+
+      context 'when the pull request is rejected' do
+        before { pull_request.reject }
+
+        it 'returns the state name' do
+          expect(subject.state).to eq 'rejected'
+        end
+      end
+    end
+  end
 end

--- a/spec/resources/topic_resource_spec.rb
+++ b/spec/resources/topic_resource_spec.rb
@@ -25,15 +25,17 @@ RSpec.describe TopicResource, :type => :resource do
   it { is_expected.to have_many(:forks).with_class_name 'Topic' }
   it { is_expected.to have_many(:assets) }
   it { is_expected.to have_many(:conversations) }
+  it { is_expected.to have_many(:incoming_pull_requests).with_class_name 'PullRequest' }
+  it { is_expected.to have_many(:outgoing_pull_requests).with_class_name 'PullRequest' }
 
   describe 'fields' do
     it 'should have a valid set of fetchable fields' do
-      expect(subject.fetchable_fields).to match_array %i[id title state description root_content_item_id user upstream content forks collaborators assets conversations]
+      expect(subject.fetchable_fields).to match_array %i[id title state description root_content_item_id user upstream content forks collaborators assets conversations incoming_pull_requests outgoing_pull_requests]
     end
 
     it 'should omit empty fields' do
       subject { described_class.new nil_topic, context }
-      expect(subject.fetchable_fields).to match_array %i[id title state description root_content_item_id user upstream content forks collaborators assets conversations]
+      expect(subject.fetchable_fields).to match_array %i[id title state description root_content_item_id user upstream content forks collaborators assets conversations incoming_pull_requests outgoing_pull_requests]
     end
 
     it 'should have a valid set of creatable fields' do

--- a/spec/routing/alerts_routing_spec.rb
+++ b/spec/routing/alerts_routing_spec.rb
@@ -3,17 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe 'alerts routing', :type => :routing do
-  it 'routes alerts endpoint' do
-    route = '/api/users/foo/alerts'
-    params = { :user_id => 'foo', :relationship => 'alerts', :source => 'users' }
-
-    expect(:get => route).to route_to 'alerts#get_related_resources', params
-    expect(:post => route).not_to be_routable
-    expect(:patch => route).not_to be_routable
-    expect(:put => route).not_to be_routable
-    expect(:delete => route).not_to be_routable
-  end
-
   it 'routes alert endpoint' do
     route = '/api/alerts/foo'
 

--- a/spec/routing/pull_requests_routing_spec.rb
+++ b/spec/routing/pull_requests_routing_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'pull requests routing', :type => :routing do
+  it 'routes pull request endpoint' do
+    route = '/api/pullRequests/foo'
+
+    expect(:get => route).to route_to 'pull_requests#show', :id => 'foo'
+    expect(:patch => route).not_to be_routable
+    expect(:put => route).not_to be_routable
+    expect(:post => route).not_to be_routable
+    expect(:delete => route).not_to be_routable
+  end
+
+  it 'routes pull_request user relationship endpoint' do
+    route = '/api/pullRequests/foo/relationships/user'
+    params = { :pull_request_id => 'foo', :relationship => 'user' }
+
+    expect(:get => '/api/pullRequests/foo/user').to route_to 'users#get_related_resource', params.merge(:source => 'pull_requests')
+
+    expect(:get => route).to route_to 'pull_requests#show_relationship', params
+    expect(:patch => route).not_to be_routable
+    expect(:put => route).not_to be_routable
+    expect(:post => route).not_to be_routable
+    expect(:delete => route).not_to be_routable
+  end
+
+  it 'routes pull_request source relationship endpoint' do
+    route = '/api/pullRequests/foo/relationships/source'
+    params = { :pull_request_id => 'foo', :relationship => 'source' }
+
+    expect(:get => '/api/pullRequests/foo/source').to route_to 'topics#get_related_resource', params.merge(:source => 'pull_requests')
+
+    expect(:get => route).to route_to 'pull_requests#show_relationship', params
+    expect(:patch => route).not_to be_routable
+    expect(:put => route).not_to be_routable
+    expect(:post => route).not_to be_routable
+    expect(:delete => route).not_to be_routable
+  end
+
+  it 'routes pull_request target relationship endpoint' do
+    route = '/api/pullRequests/foo/relationships/target'
+    params = { :pull_request_id => 'foo', :relationship => 'target' }
+
+    expect(:get => '/api/pullRequests/foo/target').to route_to 'topics#get_related_resource', params.merge(:source => 'pull_requests')
+
+    expect(:get => route).to route_to 'pull_requests#show_relationship', params
+    expect(:patch => route).not_to be_routable
+    expect(:put => route).not_to be_routable
+    expect(:post => route).not_to be_routable
+    expect(:delete => route).not_to be_routable
+  end
+end

--- a/spec/routing/pull_requests_routing_spec.rb
+++ b/spec/routing/pull_requests_routing_spec.rb
@@ -3,6 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe 'pull requests routing', :type => :routing do
+  it 'routes pull requests endpoint' do
+    route = '/api/pullRequests'
+
+    expect(:get => route).not_to be_routable
+    expect(:patch => route).not_to be_routable
+    expect(:put => route).not_to be_routable
+    expect(:post => route).to route_to 'pull_requests#create'
+    expect(:delete => route).not_to be_routable
+  end
+
   it 'routes pull request endpoint' do
     route = '/api/pullRequests/foo'
 

--- a/spec/routing/topics_routing_spec.rb
+++ b/spec/routing/topics_routing_spec.rb
@@ -100,4 +100,30 @@ RSpec.describe 'topics routing', :type => :routing do
     expect(:post => route).not_to be_routable
     expect(:delete => route).not_to be_routable
   end
+
+  it 'routes topic incoming pull requests relationship endpoint' do
+    route = '/api/topics/foo/relationships/incomingPullRequests'
+    params = { :topic_id => 'foo', :relationship => 'incomingPullRequests' }
+
+    expect(:get => '/api/topics/foo/incomingPullRequests').to route_to 'pull_requests#get_related_resources', params.merge(:source => 'topics')
+
+    expect(:get => route).to route_to 'topics#show_relationship', params
+    expect(:patch => route).not_to be_routable
+    expect(:put => route).not_to be_routable
+    expect(:post => route).not_to be_routable
+    expect(:delete => route).not_to be_routable
+  end
+
+  it 'routes topic outgoing pull requests relationship endpoint' do
+    route = '/api/topics/foo/relationships/outgoingPullRequests'
+    params = { :topic_id => 'foo', :relationship => 'outgoingPullRequests' }
+
+    expect(:get => '/api/topics/foo/outgoingPullRequests').to route_to 'pull_requests#get_related_resources', params.merge(:source => 'topics')
+
+    expect(:get => route).to route_to 'topics#show_relationship', params
+    expect(:patch => route).not_to be_routable
+    expect(:put => route).not_to be_routable
+    expect(:post => route).not_to be_routable
+    expect(:delete => route).not_to be_routable
+  end
 end

--- a/spec/routing/topics_routing_spec.rb
+++ b/spec/routing/topics_routing_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'topics routing', :type => :routing do
 
   it 'routes topic incoming pull requests relationship endpoint' do
     route = '/api/topics/foo/relationships/incomingPullRequests'
-    params = { :topic_id => 'foo', :relationship => 'incomingPullRequests' }
+    params = { :topic_id => 'foo', :relationship => 'incoming_pull_requests' }
 
     expect(:get => '/api/topics/foo/incomingPullRequests').to route_to 'pull_requests#get_related_resources', params.merge(:source => 'topics')
 
@@ -116,7 +116,7 @@ RSpec.describe 'topics routing', :type => :routing do
 
   it 'routes topic outgoing pull requests relationship endpoint' do
     route = '/api/topics/foo/relationships/outgoingPullRequests'
-    params = { :topic_id => 'foo', :relationship => 'outgoingPullRequests' }
+    params = { :topic_id => 'foo', :relationship => 'outgoing_pull_requests' }
 
     expect(:get => '/api/topics/foo/outgoingPullRequests').to route_to 'pull_requests#get_related_resources', params.merge(:source => 'topics')
 


### PR DESCRIPTION
Adds the ability to submit pull requests. See [documentation](http://localhost:4567/#pull-requests-api).

Currently only allows to create and show pull requests. Functionality to accept/reject and provide feedback will be included in a future pull request.