### PR TITLE
Add middleware to skip token authentication in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -64,4 +64,7 @@ Rails.application.configure do
   end
 
   config.active_record.sqlite3.represent_boolean_as_integer = true
+
+  # Allow specifying a user instead of an authentication token
+  config.middleware.use UserAuthentication
 end

--- a/lib/middleware/user_authentication.rb
+++ b/lib/middleware/user_authentication.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+##
+# Allow specifying a user instead of a token when authenticating
+#
+# Instead of the token authentication header:
+#
+# ```
+# Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9...
+# ```
+#
+# Set the following request header:
+#
+# ```
+# Authorization: User 1
+# ```
+#
+# Where '1' is the unique user identifier
+#
+class UserAuthentication
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    if env['HTTP_AUTHORIZATION']&.starts_with? 'User'
+      user = User.find env['HTTP_AUTHORIZATION']&.split(' ')&.last
+      token = JWT::Auth::Token.from_user(user).to_jwt if user
+      env['HTTP_AUTHORIZATION'] = "Bearer #{token}" if token
+    end
+
+    status, headers, body = @app.call env
+
+    [status, headers, body]
+  end
+end


### PR DESCRIPTION
Allows developers to skip token authentication. See [documentation](https://openwebslides.github.io/documentation/#authentication).