### PR TITLE
Alerts topic

### DIFF
--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -49,6 +49,9 @@ class Alert < ApplicationRecord
   validate :pull_request_type_fields,
            :unless => :topic_updated?
 
+  validate :topic_equals_target,
+           :unless => :topic_updated?
+
   ##
   # Callbacks
   #
@@ -78,5 +81,11 @@ class Alert < ApplicationRecord
 
     # Count must be blank
     errors.add :count, :present if count?
+  end
+
+  def topic_equals_target
+    return if topic == pull_request&.target
+
+    errors.add :topic, I18n.t('openwebslides.validations.alert.topic_equals_target')
   end
 end

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -71,12 +71,12 @@ class Alert < ApplicationRecord
   end
 
   def pull_request_type_fields
-    # Subject and pull request must be present
+    # Topic, subject and pull request must be present
+    errors.add :topic, :blank unless topic
     errors.add :subject, :blank unless subject
     errors.add :pull_request, :blank unless pull_request
 
-    # Topic and count must be blank
-    errors.add :topic, :present if topic
+    # Count must be blank
     errors.add :count, :present if count?
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,8 @@ en:
       pull_request:
         target_is_upstream_source: "must have target as upstream"
         source_has_one_open_pr: "can only have on open pull request"
+      alert:
+        topic_equals_target: "must equal pull request target topic"
     annotations:
       hidden: "[deleted]"
     mailer:

--- a/config/openwebslides.rb
+++ b/config/openwebslides.rb
@@ -75,5 +75,5 @@ OpenWebslides.configure do |config|
   # All requests with a version >= MAJOR.0 and < MAJOR.(MINOR + 1) will be processed
   # For example, if the API version is 3.2.3, requests with version 3.0 up to < 3.3 will be processed
   #
-  config.api.version = '6.0.0'
+  config.api.version = '6.1.0'
 end

--- a/spec/factories/alert_factory.rb
+++ b/spec/factories/alert_factory.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
     factory :pull_request_alert do
       alert_type { %i[pr_submitted pr_accepted pr_rejected].sample }
 
+      topic { pull_request.target }
       pull_request { build :pull_request }
       subject { build :user }
     end

--- a/spec/factories/alert_factory.rb
+++ b/spec/factories/alert_factory.rb
@@ -14,8 +14,8 @@ FactoryBot.define do
     factory :pull_request_alert do
       alert_type { %i[pr_submitted pr_accepted pr_rejected].sample }
 
-      topic { pull_request.target }
       pull_request { build :pull_request }
+      topic { pull_request.target }
       subject { build :user }
     end
   end

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -88,14 +88,14 @@ RSpec.describe Alert, :type => :model do
       context "when alert_type is `#{alert_type}`" do
         subject(:alert) { build :pull_request_alert, :alert_type => alert_type }
 
-        it { is_expected.not_to validate_presence_of :topic }
+        it { is_expected.to validate_presence_of :topic }
         it { is_expected.to validate_presence_of :pull_request }
         it { is_expected.to validate_presence_of :subject }
 
         context 'when topic is non-nil' do
           before { alert.topic = build(:topic) }
 
-          it { is_expected.not_to be_valid }
+          it { is_expected.to be_valid }
         end
 
         context 'when pull_request is non-nil' do

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -93,13 +93,22 @@ RSpec.describe Alert, :type => :model do
         it { is_expected.to validate_presence_of :subject }
 
         context 'when topic is non-nil' do
-          before { alert.topic = build(:topic) }
+          before { alert.topic = alert.pull_request.target }
 
           it { is_expected.to be_valid }
         end
 
+        context 'when topic is not equal to pull request target' do
+          before { alert.topic = build(:topic) }
+
+          it { is_expected.not_to be_valid }
+        end
+
         context 'when pull_request is non-nil' do
-          before { alert.pull_request = build(:pull_request) }
+          before do
+            alert.pull_request = build(:pull_request)
+            alert.topic = alert.pull_request.target
+          end
 
           it { is_expected.to be_valid }
         end

--- a/spec/requests/alert_spec.rb
+++ b/spec/requests/alert_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'Alerts API', :type => :request do
 
         expect(json['attributes']['alertType']).to eq 'pr_submitted'
         expect(json['relationships']['user']['data']['id']).to eq alert.user.id.to_s
-        expect(json['relationships']['topic']['data']).to be_nil
+        expect(json['relationships']['topic']['data']['id']).to eq alert.topic.id.to_s
         expect(json['relationships']['subject']['data']['id']).to eq alert.subject.id.to_s
         expect(json['relationships']['pullRequest']['data']['id']).to eq alert.pull_request.id.to_s
       end
@@ -91,7 +91,7 @@ RSpec.describe 'Alerts API', :type => :request do
 
         expect(json['attributes']['alertType']).to eq 'pr_accepted'
         expect(json['relationships']['user']['data']['id']).to eq alert.user.id.to_s
-        expect(json['relationships']['topic']['data']).to be_nil
+        expect(json['relationships']['topic']['data']['id']).to eq alert.topic.id.to_s
         expect(json['relationships']['subject']['data']['id']).to eq alert.subject.id.to_s
         expect(json['relationships']['pullRequest']['data']['id']).to eq alert.pull_request.id.to_s
       end
@@ -110,7 +110,7 @@ RSpec.describe 'Alerts API', :type => :request do
 
         expect(json['attributes']['alertType']).to eq 'pr_rejected'
         expect(json['relationships']['user']['data']['id']).to eq alert.user.id.to_s
-        expect(json['relationships']['topic']['data']).to be_nil
+        expect(json['relationships']['topic']['data']['id']).to eq alert.topic.id.to_s
         expect(json['relationships']['subject']['data']['id']).to eq alert.subject.id.to_s
         expect(json['relationships']['pullRequest']['data']['id']).to eq alert.pull_request.id.to_s
       end


### PR DESCRIPTION
Enforce `Alert#topic` relationship always present. In `topic_submitted` alert types, this is the fork. In `pr_*` alert types, this is the upstream topic.

See [documentation](https://openwebslides.github.io/documentation/#api-v6-1)