### PR TITLE
Alerts: mark as read

### DIFF
--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -26,6 +26,19 @@ class AlertsController < ApplicationController
     jsonapi_render :json => @alert
   end
 
+  # PUT/PATCH /alerts/:id
+  def update
+    @alert = Alert.find params[:id]
+
+    authorize @alert
+
+    if @alert.update resource_params
+      jsonapi_render :json => @alert
+    else
+      jsonapi_render_errors :json => @alert, :status => :unprocessable_entity
+    end
+  end
+
   ##
   # Relationships
   #

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -52,6 +52,9 @@ class Alert < ApplicationRecord
   validate :topic_equals_target,
            :unless => :topic_updated?
 
+  validate :update_read_is_true,
+           :on => :update
+
   ##
   # Callbacks
   #
@@ -87,5 +90,9 @@ class Alert < ApplicationRecord
     return if topic == pull_request&.target
 
     errors.add :topic, I18n.t('openwebslides.validations.alert.topic_equals_target')
+  end
+
+  def update_read_is_true
+    errors.add :read, I18n.t('openwebslides.validations.alert.update_read_is_true') unless read
   end
 end

--- a/app/policies/alert_policy.rb
+++ b/app/policies/alert_policy.rb
@@ -11,6 +11,11 @@ class AlertPolicy < ApplicationPolicy
     @record.user == @user
   end
 
+  def update?
+    # Only owner can update alert
+    show?
+  end
+
   ##
   # Relationship: user
   #

--- a/app/resources/alert_resource.rb
+++ b/app/resources/alert_resource.rb
@@ -4,8 +4,6 @@
 # Alert resource
 #
 class AlertResource < ApplicationResource
-  immutable
-
   ##
   # Attributes
   #
@@ -31,6 +29,10 @@ class AlertResource < ApplicationResource
   ##
   # Methods
   #
+  def self.updatable_fields(context = {})
+    super(context) - %i[alert_type count pull_request user topic subject]
+  end
+
   def self.sortable_fields(_)
     %i[created_at]
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
         source_has_one_open_pr: "can only have on open pull request"
       alert:
         topic_equals_target: "must equal pull request target topic"
+        update_read_is_true: "must be true"
     annotations:
       hidden: "[deleted]"
     mailer:

--- a/config/openwebslides.rb
+++ b/config/openwebslides.rb
@@ -75,5 +75,5 @@ OpenWebslides.configure do |config|
   # All requests with a version >= MAJOR.0 and < MAJOR.(MINOR + 1) will be processed
   # For example, if the API version is 3.2.3, requests with version 3.0 up to < 3.3 will be processed
   #
-  config.api.version = '6.1.0'
+  config.api.version = '6.2.0'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
     ##
     # Alerts API
     #
-    jsonapi_resources :alerts, :only => %i[show] do
+    jsonapi_resources :alerts, :only => %i[show update] do
       # User relationship
       jsonapi_related_resource :user
       jsonapi_link :user, :only => :show

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -21,6 +21,14 @@ RSpec.describe Alert, :type => :model do
     it { is_expected.to allow_values(false, 'false', true, 'true').for :read }
     it { is_expected.to define_enum_for(:alert_type).with %i[topic_updated pr_submitted pr_accepted pr_rejected] }
 
+    describe 'read must be true on update' do
+      subject(:alert) { create :update_alert, :alert_type => :topic_updated }
+
+      it 'is invalid' do
+        expect { alert.update! :read => false }.to raise_error ActiveRecord::RecordInvalid
+      end
+    end
+
     context 'when alert_type is `topic_updated`' do
       subject(:alert) { build :update_alert, :alert_type => :topic_updated }
 

--- a/spec/policies/alert_policy_spec.rb
+++ b/spec/policies/alert_policy_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe AlertPolicy do
     let(:user) { nil }
 
     it { is_expected.to forbid_action :show }
+    it { is_expected.to forbid_action :update }
 
     it { is_expected.to forbid_action :show_user }
     it { is_expected.to forbid_action :show_topic }
@@ -22,6 +23,7 @@ RSpec.describe AlertPolicy do
     let(:user) { build :user }
 
     it { is_expected.to forbid_action :show }
+    it { is_expected.to forbid_action :update }
 
     it { is_expected.to forbid_action :show_user }
     it { is_expected.to forbid_action :show_topic }
@@ -33,6 +35,7 @@ RSpec.describe AlertPolicy do
     let(:user) { record.user }
 
     it { is_expected.to permit_action :show }
+    it { is_expected.to permit_action :update }
 
     it { is_expected.to permit_action :show_user }
     it { is_expected.to permit_action :show_topic }

--- a/spec/resources/alert_resource_spec.rb
+++ b/spec/resources/alert_resource_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe AlertResource, :type => :resource do
       end
     end
 
+    it 'should have a valid set of updatable fields' do
+      expect(described_class.updatable_fields).to match_array %i[read]
+    end
+
     it 'has a valid set of sortable fields' do
       expect(described_class.sortable_fields context).to match_array %i[created_at]
     end

--- a/spec/routing/alerts_routing_spec.rb
+++ b/spec/routing/alerts_routing_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe 'alerts routing', :type => :routing do
     route = '/api/alerts/foo'
 
     expect(:get => route).to route_to 'alerts#show', :id => 'foo'
-    expect(:patch => route).not_to be_routable
-    expect(:put => route).not_to be_routable
+    expect(:patch => route).to route_to 'alerts#update', :id => 'foo'
+    expect(:put => route).to route_to 'alerts#update', :id => 'foo'
     expect(:post => route).not_to be_routable
     expect(:delete => route).not_to be_routable
   end


### PR DESCRIPTION
Add _mark as read_ functionality to Alerts API.

See [documentation](https://openwebslides.github.io/documentation/#mark-alert-as-read).