### PR TITLE
Topic state machine

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -26,15 +26,7 @@ class TopicsController < ApplicationController
 
   # POST /topics
   def create
-    begin
-      @topic = Topic.new topic_params
-    rescue ArgumentError
-      # FIXME: Topic.new throws ArgumentError when :state is invalid
-      # See https://github.com/rails/rails/issues/13971#issuecomment-287030984
-      # FIXME: Remove the errors check in Topics::Create
-      @topic = Topic.new topic_params.merge :state => ''
-      @topic.errors.add :state, I18n.t('openwebslides.validations.topic.invalid_state')
-    end
+    @topic = Topic.new topic_params
 
     authorize @topic
 
@@ -69,10 +61,6 @@ class TopicsController < ApplicationController
     else
       jsonapi_render_errors :json => @topic, :status => :unprocessable_entity
     end
-  rescue ArgumentError
-    # Add error to catch invalid state
-    @topic.errors.add :state, 'is invalid'
-    jsonapi_render_errors :json => @topic, :status => :unprocessable_entity
   end
 
   # DELETE /topics/:id

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -14,9 +14,6 @@ class Topic < ApplicationRecord
   # Topic description
   property :description
 
-  # Access level
-  enum :state => %i[public_access protected_access private_access]
-
   # Root content item identifier
   property :root_content_item_id
 
@@ -78,7 +75,7 @@ class Topic < ApplicationRecord
   validates :title,
             :presence => true
 
-  validates :state,
+  validates :access,
             :presence => true
 
   validates :root_content_item_id,
@@ -87,6 +84,33 @@ class Topic < ApplicationRecord
   validate :upstream_cannot_be_fork
 
   validate :upstream_xor_forks
+
+  ##
+  # State
+  #
+  state_machine :access, :initial => :public do
+    state :public
+    state :private
+    state :protected
+
+    # Make a topic private
+    event :set_private do
+      transition :public => :private,
+                 :protected => :private
+    end
+
+    # Make a topic protected
+    event :set_protected do
+      transition :public => :protected,
+                 :private => :protected
+    end
+
+    # Make a topic public
+    event :set_public do
+      transition :protected => :public,
+                 :private => :public
+    end
+  end
 
   ##
   # Callbacks

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -85,6 +85,8 @@ class Topic < ApplicationRecord
 
   validate :upstream_xor_forks
 
+  validate :more_permissive_upstream
+
   ##
   # State
   #
@@ -149,5 +151,16 @@ class Topic < ApplicationRecord
 
     errors.add :upstream, 'cannot be non-empty when forks are specified'
     errors.add :forks, 'cannot be non-empty when upstream is specified'
+  end
+
+  # Forked topics cannot be more permissive than their upstream
+  def more_permissive_upstream
+    return unless upstream
+
+    # Add error in case of (public and upstream is protected/private),
+    # or (public/protected and upstream is private)
+    return unless (public? && !upstream.public?) || !private? && upstream.private?
+
+    errors.add :access, I18n.t('openwebslides.validations.topic.more_permissive_upstream')
   end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -142,15 +142,15 @@ class Topic < ApplicationRecord
   #
   def upstream_cannot_be_fork
     # If upstream is set, it cannot reference a topic that is a fork too (where upstream is non-empty)
-    errors.add :upstream, 'cannot be a fork' if upstream&.upstream
+    errors.add :upstream, I18n.t('openwebslides.validations.topic.upstream_cannot_be_fork') if upstream&.upstream
   end
 
   def upstream_xor_forks
     # Either `forks` or `upstream` can be set
     return unless upstream && forks.any?
 
-    errors.add :upstream, 'cannot be non-empty when forks are specified'
-    errors.add :forks, 'cannot be non-empty when upstream is specified'
+    errors.add :upstream, I18n.t('openwebslides.validations.topic.upstream_xor_forks')
+    errors.add :forks, I18n.t('openwebslides.validations.topic.upstream_xor_forks')
   end
 
   # Forked topics cannot be more permissive than their upstream

--- a/app/policies/topic_policy.rb
+++ b/app/policies/topic_policy.rb
@@ -18,13 +18,13 @@ class TopicPolicy < ApplicationPolicy
 
   def show?
     # Users can show public topics, collaborations and owned topics
-    if @record.public_access?
+    if @record.public?
       # Users and guests can show
       true
-    elsif @record.protected_access?
+    elsif @record.protected?
       # Users can show protected topic
       !@user.nil?
-    elsif @record.private_access?
+    elsif @record.private?
       return false if @user.nil?
 
       # Owner and collaborators can read private topic
@@ -150,14 +150,14 @@ class TopicPolicy < ApplicationPolicy
     def resolve
       if @user
         # Users can see public topics, protected topics and collaborations
-        query = 'topics.state != ? OR topics.user_id = ? OR access_grants.user_id = ?'
+        query = 'topics.access != "private" OR topics.user_id = ? OR access_grants.user_id = ?'
 
         scope.joins('LEFT OUTER JOIN grants access_grants ON access_grants.topic_id = topics.id')
-             .where(query, Topic.states['private_access'], @user.id, @user.id)
+             .where(query, @user.id, @user.id)
              .distinct
       else
         # Everyone can see public topics
-        scope.where('topics.state' => 'public_access')
+        scope.where('topics.access' => 'public')
       end
     end
   end

--- a/app/resources/topic_resource.rb
+++ b/app/resources/topic_resource.rb
@@ -8,7 +8,7 @@ class TopicResource < ApplicationResource
   # Attributes
   #
   attribute :title
-  attribute :state
+  attribute :access
   attribute :description
   attribute :root_content_item_id
 
@@ -31,8 +31,8 @@ class TopicResource < ApplicationResource
   #
   filter :title
   filter :description
-  filter :state,
-         :verify => ->(values, _) { values & Topic.states.keys }
+  filter :access,
+         :verify => ->(values, _) { values & Topic.state_machine.states.map(&:name).map(&:to_s) }
 
   ##
   # Callbacks

--- a/app/services/topics/create.rb
+++ b/app/services/topics/create.rb
@@ -6,10 +6,6 @@ module Topics
   #
   class Create < ApplicationService
     def call(topic)
-      # Return if topic has errors already
-      # This happens because status is validated in TopicsController
-      return topic if topic.errors.any?
-
       if topic.save
         # Persist to file system
         Repository::Create.new(topic).execute

--- a/app/services/topics/fork.rb
+++ b/app/services/topics/fork.rb
@@ -8,7 +8,7 @@ module Topics
     def call(topic, user)
       fork_params = topic.slice :title,
                                 :description,
-                                :state,
+                                :access,
                                 :root_content_item_id
 
       @fork = Topic.new fork_params

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,8 @@ en:
         topic_equals_target: "must equal pull request target topic"
         update_read_is_true: "must be true"
       topic:
+        upstream_cannot_be_fork: "cannot be a fork"
+        upstream_xor_forks: "cannot be non-empty when forks are specified"
         more_permissive_upstream: "cannot be more permissive than the upstream topic"
     annotations:
       hidden: "[deleted]"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,7 +36,7 @@ en:
         topic_equals_target: "must equal pull request target topic"
         update_read_is_true: "must be true"
       topic:
-        invalid_state: "is invalid"
+        more_permissive_upstream: "cannot be more permissive than the upstream topic"
     annotations:
       hidden: "[deleted]"
     mailer:

--- a/config/openwebslides.rb
+++ b/config/openwebslides.rb
@@ -72,5 +72,5 @@ OpenWebslides.configure do |config|
   ##
   # API version
   #
-  config.api.version = '7.1.0'
+  config.api.version = '8.0.0'
 end

--- a/db/migrate/20181123123825_migrate_topic_to_state_machine.rb
+++ b/db/migrate/20181123123825_migrate_topic_to_state_machine.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class MigrateTopicToStateMachine < ActiveRecord::Migration[5.2]
+  def change
+    Topic.transaction do
+      add_column :topics, :access, :string, :null => false, :default => ''
+
+      map_state_to_access = {
+        'public_access' => 'public',
+        'protected_access' => 'protected',
+        'private_access' => 'private'
+      }
+
+      Topic.all.each do |topic|
+        topic.update! :access => map_state_to_access[topic.state]
+
+        topic.reload
+
+        raise 'Value is not equal to old value' unless topic.attributes_before_type_cast['access'] == map_state_to_access[topic.state]
+        raise 'Value is not legal' unless %w[public protected private].include?(topic.access)
+      end
+
+      remove_column :topics, :state
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_21_161659) do
+ActiveRecord::Schema.define(version: 2018_11_23_123825) do
 
   create_table "alerts", force: :cascade do |t|
     t.integer "user_id"
@@ -108,13 +108,13 @@ ActiveRecord::Schema.define(version: 2018_11_21_161659) do
 
   create_table "topics", force: :cascade do |t|
     t.string "title"
-    t.integer "state", default: 0
     t.string "description"
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "root_content_item_id"
     t.integer "upstream_id"
+    t.string "access", default: "", null: false
     t.index ["upstream_id"], name: "index_topics_on_upstream_id"
     t.index ["user_id"], name: "index_topics_on_user_id"
   end

--- a/lib/tasks/sample.rake
+++ b/lib/tasks/sample.rake
@@ -76,7 +76,7 @@ namespace :db do
 
         deck_count.times do
           deck = user.topics.build :name => Faker::Lorem.words.join(' '),
-                                   :state => %i[public_access protected_access private_access].sample
+                                   :access => %i[public protected private].sample
 
           # 80% of the decks have a description
           deck.description = Faker::Lorem.words(10).join(' ') if prob 0.8

--- a/spec/acceptance/topic_spec.rb
+++ b/spec/acceptance/topic_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Topic', :type => :request do
           :attributes => {
             :title => title,
             :description => description,
-            :state => 'private_access',
+            :access => 'private',
             :rootContentItemId => 'ivks4jgtxr'
           },
           :relationships => {
@@ -87,7 +87,7 @@ RSpec.describe 'Topic', :type => :request do
       data = JSON.parse(response.body)['data']
       expect(data['attributes']).to match 'title' => title,
                                           'description' => description,
-                                          'state' => 'private_access',
+                                          'access' => 'private',
                                           'rootContentItemId' => 'ivks4jgtxr'
     end
   end

--- a/spec/factories/topic_factory.rb
+++ b/spec/factories/topic_factory.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     title { Faker::Lorem.words(4).join ' ' }
     description { Faker::Lorem.words(20).join ' ' }
     root_content_item_id { Faker::Lorem.words(3).join '' }
-    state :public_access
     user { build :user, :confirmed }
+    access { :public }
 
     trait :with_collaborators do
       collaborators { build_list :user, 3 }

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -44,6 +44,74 @@ RSpec.describe Topic, :type => :model do
     end
 
     it { is_expected.to be_valid }
+
+    describe 'cannot have a more permissive access level than the upstream' do
+      context 'when the upstream is public' do
+        let(:upstream) { create :topic, :access => :public }
+
+        context 'when the fork is public' do
+          let(:topic) { build :topic, :upstream => upstream, :access => :public }
+
+          it { is_expected.to be_valid }
+        end
+
+        context 'when the fork is protected' do
+          let(:topic) { build :topic, :upstream => upstream, :access => :protected }
+
+          it { is_expected.to be_valid }
+        end
+
+        context 'when the fork is private' do
+          let(:topic) { build :topic, :upstream => upstream, :access => :private }
+
+          it { is_expected.to be_valid }
+        end
+      end
+
+      context 'when the upstream is protected' do
+        let(:upstream) { create :topic, :access => :protected }
+
+        context 'when the fork is public' do
+          let(:topic) { build :topic, :upstream => upstream, :access => :public }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context 'when the fork is protected' do
+          let(:topic) { build :topic, :upstream => upstream, :access => :protected }
+
+          it { is_expected.to be_valid }
+        end
+
+        context 'when the fork is private' do
+          let(:topic) { build :topic, :upstream => upstream, :access => :private }
+
+          it { is_expected.to be_valid }
+        end
+      end
+
+      context 'when the upstream is private' do
+        let(:upstream) { create :topic, :access => :private }
+
+        context 'when the fork is public' do
+          let(:topic) { build :topic, :upstream => upstream, :access => :public }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context 'when the fork is protected' do
+          let(:topic) { build :topic, :upstream => upstream, :access => :protected }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context 'when the fork is private' do
+          let(:topic) { build :topic, :upstream => upstream, :access => :private }
+
+          it { is_expected.to be_valid }
+        end
+      end
+    end
   end
 
   describe 'state machine' do

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -36,9 +36,6 @@ RSpec.describe Topic, :type => :model do
     it { is_expected.not_to allow_value(nil).for(:title) }
     it { is_expected.not_to allow_value('').for(:title) }
 
-    it { is_expected.not_to allow_value(nil).for(:state) }
-    it { is_expected.not_to allow_value('').for(:state) }
-
     it { is_expected.not_to allow_value(nil).for(:root_content_item_id) }
     it { is_expected.not_to allow_value('').for(:root_content_item_id) }
 
@@ -47,9 +44,32 @@ RSpec.describe Topic, :type => :model do
     end
 
     it { is_expected.to be_valid }
+  end
 
-    it 'has a valid :status enum' do
-      expect(%w[public_access protected_access private_access]).to include subject.state
+  describe 'state machine' do
+    let(:subject) { build :topic }
+
+    it { is_expected.to have_states :public, :private, :protected }
+
+    context 'when the topic is public' do
+      it { is_expected.to handle_events :set_private, :set_protected, :when => :public }
+
+      it { is_expected.to transition_from :public, :to_state => :private, :on_event => :set_private }
+      it { is_expected.to transition_from :public, :to_state => :protected, :on_event => :set_protected }
+    end
+
+    context 'when the topic is protected' do
+      it { is_expected.to handle_events :set_private, :set_public, :when => :protected }
+
+      it { is_expected.to transition_from :protected, :to_state => :private, :on_event => :set_private }
+      it { is_expected.to transition_from :protected, :to_state => :public, :on_event => :set_public }
+    end
+
+    context 'when the topic is private' do
+      it { is_expected.to handle_events :set_protected, :set_public, :when => :private }
+
+      it { is_expected.to transition_from :private, :to_state => :protected, :on_event => :set_protected }
+      it { is_expected.to transition_from :private, :to_state => :public, :on_event => :set_public }
     end
   end
 

--- a/spec/policies/annotation_policy_spec.rb
+++ b/spec/policies/annotation_policy_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe AnnotationPolicy do
   let(:annotation) { build :annotation, :topic => topic }
 
   context 'for public topics' do
-    let(:topic) { build :topic, :with_collaborators, :state => :public_access }
+    let(:topic) { build :topic, :with_collaborators, :access => :public }
 
     context 'for a guest' do
       let(:user) { nil }
@@ -79,7 +79,7 @@ RSpec.describe AnnotationPolicy do
   end
 
   context 'for protected topics' do
-    let(:topic) { build :topic, :with_collaborators, :state => :protected_access }
+    let(:topic) { build :topic, :with_collaborators, :access => :protected }
 
     context 'for a guest' do
       let(:user) { nil }
@@ -150,7 +150,7 @@ RSpec.describe AnnotationPolicy do
   end
 
   context 'for private topics' do
-    let(:topic) { build :topic, :with_collaborators, :state => :private_access }
+    let(:topic) { build :topic, :with_collaborators, :access => :private }
 
     context 'for a guest' do
       let(:user) { nil }

--- a/spec/policies/asset_policy_spec.rb
+++ b/spec/policies/asset_policy_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe AssetPolicy do
   let(:asset) { topic.assets.first }
 
   context 'for public topics' do
-    let(:topic) { build :topic, :with_assets, :with_collaborators, :state => :public_access }
+    let(:topic) { build :topic, :with_assets, :with_collaborators, :access => :public }
 
     context 'for a guest' do
       let(:user) { nil }
@@ -72,7 +72,7 @@ RSpec.describe AssetPolicy do
   end
 
   context 'for protected topics' do
-    let(:topic) { build :topic, :with_assets, :with_collaborators, :state => :protected_access }
+    let(:topic) { build :topic, :with_assets, :with_collaborators, :access => :protected }
 
     context 'for a guest' do
       let(:user) { nil }
@@ -136,7 +136,7 @@ RSpec.describe AssetPolicy do
   end
 
   context 'for private topics' do
-    let(:topic) { build :topic, :with_assets, :with_collaborators, :state => :private_access }
+    let(:topic) { build :topic, :with_assets, :with_collaborators, :access => :private }
 
     context 'for a guest' do
       let(:user) { nil }

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CommentPolicy do
   let(:comment) { build :comment, :topic => topic }
 
   context 'for public topics' do
-    let(:topic) { build :topic, :with_collaborators, :state => :public_access }
+    let(:topic) { build :topic, :with_collaborators, :access => :public }
 
     context 'for a guest' do
       let(:user) { nil }
@@ -42,7 +42,7 @@ RSpec.describe CommentPolicy do
   end
 
   context 'for protected topics' do
-    let(:topic) { build :topic, :with_collaborators, :state => :protected_access }
+    let(:topic) { build :topic, :with_collaborators, :access => :protected }
 
     context 'for a guest' do
       let(:user) { nil }
@@ -76,7 +76,7 @@ RSpec.describe CommentPolicy do
   end
 
   context 'for private topics' do
-    let(:topic) { build :topic, :with_collaborators, :state => :private_access }
+    let(:topic) { build :topic, :with_collaborators, :access => :private }
 
     context 'for a guest' do
       let(:user) { nil }

--- a/spec/policies/conversation_policy_spec.rb
+++ b/spec/policies/conversation_policy_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ConversationPolicy do
   let(:conversation) { build :conversation, :topic => topic }
 
   context 'for public topics' do
-    let(:topic) { build :topic, :with_collaborators, :state => :public_access }
+    let(:topic) { build :topic, :with_collaborators, :access => :public }
 
     context 'for a guest' do
       let(:user) { nil }
@@ -42,7 +42,7 @@ RSpec.describe ConversationPolicy do
   end
 
   context 'for protected topics' do
-    let(:topic) { build :topic, :with_collaborators, :state => :protected_access }
+    let(:topic) { build :topic, :with_collaborators, :access => :protected }
 
     context 'for a guest' do
       let(:user) { nil }
@@ -76,7 +76,7 @@ RSpec.describe ConversationPolicy do
   end
 
   context 'for private topics' do
-    let(:topic) { build :topic, :with_collaborators, :state => :private_access }
+    let(:topic) { build :topic, :with_collaborators, :access => :private }
 
     context 'for a guest' do
       let(:user) { nil }

--- a/spec/policies/feed_item_policy_scope_spec.rb
+++ b/spec/policies/feed_item_policy_scope_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe FeedItemPolicy::Scope do
   before :each do
     d1 = create :topic
     d2 = create :topic, :user => owner
-    d3 = create :topic, :state => :protected_access
-    d4 = create :topic, :state => :private_access
-    d5 = create :topic, :state => :private_access, :user => owner
+    d3 = create :topic, :access => :protected
+    d4 = create :topic, :access => :private
+    d5 = create :topic, :access => :private, :user => owner
 
     create :feed_item, :topic => d1, :user => d1.user
     create :feed_item, :topic => d2, :user => d2.user

--- a/spec/policies/feed_item_policy_spec.rb
+++ b/spec/policies/feed_item_policy_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe FeedItemPolicy do
   let(:record) { build :feed_item, :topic => topic }
 
   context 'public topics' do
-    let(:topic) { create :topic, :state => 'public_access' }
+    let(:topic) { create :topic, :access => :public }
 
     context 'for a guest' do
       let(:user) { nil }
@@ -32,7 +32,7 @@ RSpec.describe FeedItemPolicy do
   end
 
   context 'protected topics' do
-    let(:topic) { create :topic, :state => 'protected_access' }
+    let(:topic) { create :topic, :access => :protected }
 
     context 'for a guest' do
       let(:user) { nil }
@@ -56,7 +56,7 @@ RSpec.describe FeedItemPolicy do
   end
 
   context 'private topics' do
-    let(:topic) { create :topic, :state => 'private_access' }
+    let(:topic) { create :topic, :access => :private }
 
     context 'for a guest' do
       let(:user) { nil }

--- a/spec/policies/pull_request_policy_spec.rb
+++ b/spec/policies/pull_request_policy_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe PullRequestPolicy do
       end
 
       context 'when the target is not showable' do
-        before { record.target.update :state => :private_access }
+        before { record.target.update :access => :private }
 
         it { is_expected.to forbid_action :create }
       end

--- a/spec/policies/rating_policy_spec.rb
+++ b/spec/policies/rating_policy_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RatingPolicy do
   let(:rating) { build :rating, :user => user, :annotation => topic.conversations.first }
 
   context 'for public topics' do
-    let(:topic) { build :topic, :with_conversations, :with_collaborators, :state => :public_access }
+    let(:topic) { build :topic, :with_conversations, :with_collaborators, :access => :public }
 
     context 'for a guest' do
       let(:user) { nil }
@@ -40,7 +40,7 @@ RSpec.describe RatingPolicy do
   end
 
   context 'for protected topics' do
-    let(:topic) { build :topic, :with_conversations, :with_collaborators, :state => :protected_access }
+    let(:topic) { build :topic, :with_conversations, :with_collaborators, :access => :protected }
 
     context 'for a guest' do
       let(:user) { nil }
@@ -72,7 +72,7 @@ RSpec.describe RatingPolicy do
   end
 
   context 'for private topics' do
-    let(:topic) { build :topic, :with_conversations, :with_collaborators, :state => :private_access }
+    let(:topic) { build :topic, :with_conversations, :with_collaborators, :access => :private }
 
     context 'for a guest' do
       let(:user) { nil }

--- a/spec/policies/topic_policy_spec.rb
+++ b/spec/policies/topic_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe TopicPolicy do
   subject { described_class.new user, topic }
 
-  let(:topic) { build :topic, :state => :public_access, :user => user }
+  let(:topic) { build :topic, :access => 'public', :user => user }
 
   context 'for a guest' do
     let(:user) { nil }
@@ -18,7 +18,7 @@ RSpec.describe TopicPolicy do
     end
 
     context 'for public topics' do
-      let(:topic) { build :topic, :state => :public_access }
+      let(:topic) { build :topic, :access => 'public' }
       it 'should permit only read' do
         expect(subject).to permit_action :show
         expect(subject).to forbid_action :update
@@ -39,7 +39,7 @@ RSpec.describe TopicPolicy do
     end
 
     context 'for protected topics' do
-      let(:topic) { build :topic, :state => :protected_access }
+      let(:topic) { build :topic, :access => 'protected' }
       it 'should not permit anything' do
         expect(subject).to forbid_action :show
         expect(subject).to forbid_action :update
@@ -60,7 +60,7 @@ RSpec.describe TopicPolicy do
     end
 
     context 'for private topics' do
-      let(:topic) { build :topic, :state => :private_access }
+      let(:topic) { build :topic, :access => 'private' }
       it 'should not permit anything' do
         expect(subject).to forbid_action :show
         expect(subject).to forbid_action :update
@@ -92,7 +92,7 @@ RSpec.describe TopicPolicy do
     end
 
     context 'for public topics' do
-      let(:topic) { build :topic, :state => :public_access }
+      let(:topic) { build :topic, :access => 'public' }
       it 'should permit only read' do
         expect(subject).to permit_action :show
         expect(subject).to forbid_action :update
@@ -113,7 +113,7 @@ RSpec.describe TopicPolicy do
     end
 
     context 'for protected topics' do
-      let(:topic) { build :topic, :state => :protected_access }
+      let(:topic) { build :topic, :access => 'protected' }
       it 'should permit only read' do
         expect(subject).to permit_action :show
         expect(subject).to forbid_action :update
@@ -134,7 +134,7 @@ RSpec.describe TopicPolicy do
     end
 
     context 'for private topics' do
-      let(:topic) { build :topic, :state => :private_access }
+      let(:topic) { build :topic, :access => 'private' }
       it 'should not permit anything' do
         expect(subject).to forbid_action :show
         expect(subject).to forbid_action :update
@@ -166,7 +166,7 @@ RSpec.describe TopicPolicy do
     end
 
     context 'for public topics' do
-      let(:topic) { build :topic, :with_collaborators, :state => :public_access }
+      let(:topic) { build :topic, :with_collaborators, :access => 'public' }
       let(:user) { topic.collaborators.first }
       it 'should permit update' do
         expect(subject).to permit_action :show
@@ -188,7 +188,7 @@ RSpec.describe TopicPolicy do
     end
 
     context 'for protected topics' do
-      let(:topic) { build :topic, :with_collaborators, :state => :protected_access }
+      let(:topic) { build :topic, :with_collaborators, :access => 'protected' }
       let(:user) { topic.collaborators.first }
       it 'should not permit anything' do
         expect(subject).to permit_action :show
@@ -210,7 +210,7 @@ RSpec.describe TopicPolicy do
     end
 
     context 'for private topics' do
-      let(:topic) { build :topic, :with_collaborators, :state => :private_access }
+      let(:topic) { build :topic, :with_collaborators, :access => 'private' }
       let(:user) { topic.collaborators.first }
       it 'should not permit anything' do
         expect(subject).to permit_action :show
@@ -243,7 +243,7 @@ RSpec.describe TopicPolicy do
     end
 
     context 'for public topics' do
-      let(:topic) { build :topic, :state => :public_access }
+      let(:topic) { build :topic, :access => 'public' }
       let(:user) { topic.user }
       it 'should permit everything' do
         expect(subject).to permit_action :show
@@ -265,7 +265,7 @@ RSpec.describe TopicPolicy do
     end
 
     context 'for protected topics' do
-      let(:topic) { build :topic, :state => :protected_access }
+      let(:topic) { build :topic, :access => 'protected' }
       let(:user) { topic.user }
       it 'should permit everything' do
         expect(subject).to permit_action :show
@@ -287,7 +287,7 @@ RSpec.describe TopicPolicy do
     end
 
     context 'for private topics' do
-      let(:topic) { build :topic, :state => :private_access }
+      let(:topic) { build :topic, :access => 'private' }
       let(:user) { topic.user }
       it 'should permit everything' do
         expect(subject).to permit_action :show

--- a/spec/resources/topic_resource_spec.rb
+++ b/spec/resources/topic_resource_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe TopicResource, :type => :resource do
   it { is_expected.to have_primary_key :id }
 
   it { is_expected.to have_attribute :title }
-  it { is_expected.to have_attribute :state }
+  it { is_expected.to have_attribute :access }
   it { is_expected.to have_attribute :root_content_item_id }
   it { is_expected.to have_attribute :description }
 
@@ -30,37 +30,37 @@ RSpec.describe TopicResource, :type => :resource do
 
   describe 'fields' do
     it 'should have a valid set of fetchable fields' do
-      expect(subject.fetchable_fields).to match_array %i[id title state description root_content_item_id user upstream content forks collaborators assets conversations incoming_pull_requests outgoing_pull_requests]
+      expect(subject.fetchable_fields).to match_array %i[id title access description root_content_item_id user upstream content forks collaborators assets conversations incoming_pull_requests outgoing_pull_requests]
     end
 
     it 'should omit empty fields' do
       subject { described_class.new nil_topic, context }
-      expect(subject.fetchable_fields).to match_array %i[id title state description root_content_item_id user upstream content forks collaborators assets conversations incoming_pull_requests outgoing_pull_requests]
+      expect(subject.fetchable_fields).to match_array %i[id title access description root_content_item_id user upstream content forks collaborators assets conversations incoming_pull_requests outgoing_pull_requests]
     end
 
     it 'should have a valid set of creatable fields' do
-      expect(described_class.creatable_fields).to match_array %i[title state description root_content_item_id user]
+      expect(described_class.creatable_fields).to match_array %i[title access description root_content_item_id user]
     end
 
     it 'should have a valid set of updatable fields' do
-      expect(described_class.updatable_fields).to match_array %i[title state description user]
+      expect(described_class.updatable_fields).to match_array %i[title access description user]
     end
 
     it 'should have a valid set of sortable fields' do
-      expect(described_class.sortable_fields context).to match_array %i[id title state description]
+      expect(described_class.sortable_fields context).to match_array %i[id title access description]
     end
   end
 
   describe 'filters' do
     it 'should have a valid set of filters' do
-      expect(described_class.filters.keys).to match_array %i[id title state description]
+      expect(described_class.filters.keys).to match_array %i[id title access description]
     end
 
-    let(:verify) { described_class.filters[:state][:verify] }
+    let(:verify) { described_class.filters[:access][:verify] }
 
-    it 'should verify state' do
-      expect(verify.call(%w[public_access foo protected_access private_access bar], {}))
-        .to match_array %w[public_access protected_access private_access]
+    it 'should verify access' do
+      expect(verify.call(%w[public foo protected private bar], {}))
+        .to match_array %w[public protected private]
     end
   end
 end

--- a/spec/services/topics/fork_spec.rb
+++ b/spec/services/topics/fork_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Topics::Fork do
     it 'attributes' do
       is_expected.to have_attributes :title => I18n.t('openwebslides.topics.forked', :title => topic.title),
                                      :description => topic.description,
-                                     :state => topic.state,
+                                     :access => topic.access,
                                      :root_content_item_id => topic.root_content_item_id,
                                      :upstream => topic,
                                      :user => user

--- a/spec/support/policy_sample_context.rb
+++ b/spec/support/policy_sample_context.rb
@@ -10,32 +10,32 @@ RSpec.shared_context 'policy_sample', :shared_context => :metadata do
 
       # User 1
       create :topic, :with_assets, :with_conversations, :user => u1, :title => 'u1d1'
-      create :topic, :with_assets, :with_conversations, :user => u1, :title => 'u1d2', :state => :protected_access
-      create :topic, :with_assets, :with_conversations, :user => u1, :title => 'u1d3', :state => :private_access
-      user = create :topic, :with_assets, :with_conversations, :user => u1, :title => 'u1d4', :state => :private_access
+      create :topic, :with_assets, :with_conversations, :user => u1, :title => 'u1d2', :access => :protected
+      create :topic, :with_assets, :with_conversations, :user => u1, :title => 'u1d3', :access => :private
+      user = create :topic, :with_assets, :with_conversations, :user => u1, :title => 'u1d4', :access => :private
       user.collaborators << u2
       user.collaborators << u3
 
       # User 2
       create :topic, :with_assets, :with_conversations, :user => u2, :title => 'u2d1'
-      create :topic, :with_assets, :with_conversations, :user => u2, :title => 'u2d2', :state => :protected_access
-      create :topic, :with_assets, :with_conversations, :user => u2, :title => 'u2d3', :state => :private_access
-      user = create :topic, :with_assets, :with_conversations, :user => u2, :title => 'u2d4', :state => :private_access
+      create :topic, :with_assets, :with_conversations, :user => u2, :title => 'u2d2', :access => :protected
+      create :topic, :with_assets, :with_conversations, :user => u2, :title => 'u2d3', :access => :private
+      user = create :topic, :with_assets, :with_conversations, :user => u2, :title => 'u2d4', :access => :private
       user.collaborators << u1
       user.collaborators << u3
 
       # User 3
       create :topic, :with_assets, :with_conversations, :user => u3, :title => 'u3d1'
-      create :topic, :with_assets, :with_conversations, :user => u3, :title => 'u3d2', :state => :protected_access
-      create :topic, :with_assets, :with_conversations, :user => u3, :title => 'u3d3', :state => :private_access
-      user = create :topic, :with_assets, :with_conversations, :user => u3, :title => 'u3d4', :state => :private_access
+      create :topic, :with_assets, :with_conversations, :user => u3, :title => 'u3d2', :access => :protected
+      create :topic, :with_assets, :with_conversations, :user => u3, :title => 'u3d3', :access => :private
+      user = create :topic, :with_assets, :with_conversations, :user => u3, :title => 'u3d4', :access => :private
       user.collaborators << u1
       user.collaborators << u2
 
       # User 4
       create :topic, :with_assets, :with_conversations, :user => u4, :title => 'u4d1'
-      create :topic, :with_assets, :with_conversations, :user => u4, :title => 'u4d2', :state => :protected_access
-      create :topic, :with_assets, :with_conversations, :user => u4, :title => 'u4d3', :state => :private_access
+      create :topic, :with_assets, :with_conversations, :user => u4, :title => 'u4d2', :access => :protected
+      create :topic, :with_assets, :with_conversations, :user => u4, :title => 'u4d3', :access => :private
     end
   end
 end


### PR DESCRIPTION
Migrate the `state` enum in Topic to a state machine in the `access` attribute.

See [documentation](https://openwebslides.github.io/documentation/#permission-model).