### PR TITLE
Require old password on user update

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,9 +30,11 @@ class UsersController < ApplicationController
     authorize @user
 
     if @user.save
-      jsonapi_render :json => @user, :status => :created
+      jsonapi_render :json => @user,
+                     :status => :created
     else
-      jsonapi_render_errors :json => @user, :status => :unprocessable_entity
+      jsonapi_render_errors :json => @user,
+                            :status => :unprocessable_entity
     end
   end
 
@@ -51,10 +53,14 @@ class UsersController < ApplicationController
 
     authorize @user
 
-    if @user.update resource_params
+    # If :password is being updated, required :current_password as well
+    method = resource_params.include?(:password) ? :update_with_password : :update_without_password
+
+    if @user.send method, resource_params
       jsonapi_render :json => @user
     else
-      jsonapi_render_errors :json => @user, :status => :unprocessable_entity
+      jsonapi_render_errors :json => @user,
+                            :status => :unprocessable_entity
     end
   end
 

--- a/app/resources/user_resource.rb
+++ b/app/resources/user_resource.rb
@@ -11,6 +11,7 @@ class UserResource < ApplicationResource
   attribute :email
   attribute :gravatar_hash
   attribute :locale
+  attribute :current_password
   attribute :password
   attribute :tos_accepted
   attribute :alert_emails
@@ -39,14 +40,14 @@ class UserResource < ApplicationResource
   #
   def fetchable_fields
     if context[:current_user] == _model
-      super - %i[password tos_accepted]
+      super - %i[current_password password tos_accepted]
     else
-      super - %i[email locale password tos_accepted alert_emails]
+      super - %i[email locale current_password password tos_accepted alert_emails]
     end
   end
 
   def self.creatable_fields(context = {})
-    super(context) - %i[gravatar_hash topics collaborations alerts]
+    super(context) - %i[current_password gravatar_hash topics collaborations alerts]
   end
 
   def self.updatable_fields(context = {})
@@ -54,7 +55,7 @@ class UserResource < ApplicationResource
   end
 
   def self.sortable_fields(context)
-    super(context) - %i[gravatar_hash locale password tos_accepted alert_emails alerts]
+    super(context) - %i[gravatar_hash locale current_password password tos_accepted alert_emails alerts]
   end
 
   ##

--- a/config/openwebslides.rb
+++ b/config/openwebslides.rb
@@ -77,5 +77,5 @@ OpenWebslides.configure do |config|
   ##
   # API version
   #
-  config.api.version = '8.0.1'
+  config.api.version = '9.0.0'
 end

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+##
+# User acceptance test
+#
+RSpec.describe 'User', :type => :request do
+  ##
+  # Configuration
+  #
+  ##
+  # Test variables
+  #
+  let(:user) { create :user, :confirmed, :password => 'abcd1234' }
+
+  let(:name) { Faker::Name.name }
+
+  ##
+  # Tests
+  #
+  describe 'update account' do
+    it 'returns successfully' do
+      params = {
+        :data => {
+          :type => 'users',
+          :id => user.id,
+          :attributes => {
+            :name => name,
+            :locale => 'en',
+            :alertEmails => false,
+            :currentPassword => 'abcd1234',
+            :password => 'abcd1235'
+          }
+        }
+      }
+
+      headers = {
+        'Content-Type' => 'application/vnd.api+json',
+        'Accept' => "application/vnd.api+json, application/vnd.openwebslides+json; version=#{OpenWebslides.config.api.version}",
+        'Authorization' => "Bearer #{JWT::Auth::Token.from_user(user).to_jwt}"
+      }
+
+      patch "/api/users/#{user.id}", :params => params.to_json, :headers => headers
+
+      expect(response.status).to eq 200
+
+      json = JSON.parse(response.body)['data']
+
+      expect(json['id']).to eq user.id.to_s
+      expect(json['attributes']['name']).to eq name
+      expect(json['attributes']['locale']).to eq 'en'
+      expect(json['attributes']['alertEmails']).to eq false
+
+      user.reload
+      expect(user).to be_valid_password 'abcd1235'
+    end
+  end
+end

--- a/spec/resources/user_resource_spec.rb
+++ b/spec/resources/user_resource_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe UserResource, :type => :resource do
     end
 
     it 'has a valid set of updatable fields' do
-      expect(described_class.updatable_fields).to match_array %i[name locale password topics collaborations alert_emails]
+      expect(described_class.updatable_fields).to match_array %i[name locale current_password password topics collaborations alert_emails]
     end
 
     it 'has a valid set of sortable fields' do


### PR DESCRIPTION
Require user's `current_password` when setting a new password